### PR TITLE
Define other API types and finish the implementation of LighthouseAuthApi

### DIFF
--- a/src/api/auth/LighthouseAuthApi.ts
+++ b/src/api/auth/LighthouseAuthApi.ts
@@ -30,6 +30,7 @@ interface ApiToken {
   username: string;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 interface ApiRole {
   id: number;
   created_at: string;
@@ -37,6 +38,7 @@ interface ApiRole {
   name: string;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 interface ApiRegistrationKey {
   id: number;
   created_at: string;
@@ -69,7 +71,7 @@ export class LighthouseAuthApi implements AuthApi {
         username,
         password,
         registration_key: registrationKey,
-        email: "todo@example.com" // TODO: add email to parameters
+        email: 'todo@example.com', // TODO: add email to parameters
       }),
     });
     const apiUser: ApiUser = await apiSignUpResponse.json();
@@ -130,7 +132,7 @@ export class LighthouseAuthApi implements AuthApi {
     const apiUsersResponse = await fetch(`${this.url}/users`, {
       credentials: 'include',
     });
-    const apiUsers: ApiUser[] = await apiUsersResponse.json()
+    const apiUsers: ApiUser[] = await apiUsersResponse.json();
     const users: User[] = apiUsers.map(apiUser => {
       const user: User = {
         username: apiUser.username,
@@ -148,9 +150,12 @@ export class LighthouseAuthApi implements AuthApi {
     if (!this.user) {
       return null;
     }
-    const apiTokenResponse = await fetch(`${this.url}/users/${this.user.id}/api-token`, {
-      credentials: 'include',
-    });
+    const apiTokenResponse = await fetch(
+      `${this.url}/users/${this.user.id}/api-token`,
+      {
+        credentials: 'include',
+      }
+    );
     const apiToken: ApiToken = await apiTokenResponse.json();
     const token: Token = {
       value: apiToken.api_token,

--- a/src/api/auth/LighthouseAuthApi.ts
+++ b/src/api/auth/LighthouseAuthApi.ts
@@ -145,7 +145,10 @@ export class LighthouseAuthApi implements AuthApi {
   }
 
   async getToken(): Promise<Token | null> {
-    const apiTokenResponse = await fetch(`${this.url}/users/${this.user?.id}/api-token`, {
+    if (!this.user) {
+      return null;
+    }
+    const apiTokenResponse = await fetch(`${this.url}/users/${this.user.id}/api-token`, {
       credentials: 'include',
     });
     const apiToken: ApiToken = await apiTokenResponse.json();

--- a/src/api/auth/LighthouseAuthApi.ts
+++ b/src/api/auth/LighthouseAuthApi.ts
@@ -103,7 +103,7 @@ export class LighthouseAuthApi implements AuthApi {
     });
 
     const apiUser: ApiUser = await apiUserResponse.json();
-    this.user = apiUser;
+    this.apiUser = apiUser;
 
     const user: User = {
       username: apiUser.username,
@@ -147,11 +147,11 @@ export class LighthouseAuthApi implements AuthApi {
   }
 
   async getToken(): Promise<Token | null> {
-    if (!this.user) {
+    if (!this.apiUser) {
       return null;
     }
     const apiTokenResponse = await fetch(
-      `${this.url}/users/${this.user.id}/api-token`,
+      `${this.url}/users/${this.apiUser.id}/api-token`,
       {
         credentials: 'include',
       }

--- a/src/api/auth/LighthouseAuthApi.ts
+++ b/src/api/auth/LighthouseAuthApi.ts
@@ -5,10 +5,12 @@ import { User } from '@luna/api/auth/User';
 // TODO: Auto-generate these types from the Swagger definition?
 
 interface ApiUser {
-  created_at: string;
-  email: string;
   id: number;
+  created_at: string;
+  updated_at: string;
   last_login: string;
+  username: string;
+  email: string;
   permanent_api_token: boolean;
   registration_key?: {
     created_at: string;
@@ -19,12 +21,34 @@ interface ApiUser {
     permanent: boolean;
     updated_at: string;
   };
-  updated_at: string;
+}
+
+interface ApiToken {
+  api_token: string;
+  expires_at: string;
+  roles: [string];
   username: string;
 }
 
+interface ApiRole {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  name: string;
+}
+
+interface ApiRegistrationKey {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  expires_at: string;
+  key: string;
+  description: string;
+  permanent: boolean;
+}
+
 export class LighthouseAuthApi implements AuthApi {
-  private user?: User;
+  private user?: ApiUser;
 
   constructor(
     private readonly url: string = 'https://lighthouse.uni-kiel.de/api'
@@ -35,7 +59,28 @@ export class LighthouseAuthApi implements AuthApi {
     username?: string,
     password?: string
   ): Promise<User | null> {
-    throw new Error('Method not implemented.');
+    const apiSignUpResponse = await fetch(`${this.url}/register`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        username,
+        password,
+        registration_key: registrationKey,
+        email: "todo@example.com" // TODO: add email to parameters
+      }),
+    });
+    const apiUser: ApiUser = await apiSignUpResponse.json();
+    const user: User = {
+      username: apiUser.username,
+      role: undefined, // TODO: change role to roles
+      course: apiUser.registration_key?.key,
+      createdAt: new Date(apiUser.created_at),
+      lastSeen: new Date(apiUser.last_login),
+    };
+    return user;
   }
 
   async logIn(username?: string, password?: string): Promise<User | null> {
@@ -43,7 +88,7 @@ export class LighthouseAuthApi implements AuthApi {
       return null;
     }
 
-    await fetch(`${this.url}/login`, {
+    const apiUserResponse = await fetch(`${this.url}/login`, {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -55,19 +100,16 @@ export class LighthouseAuthApi implements AuthApi {
       }),
     });
 
-    const apiUserResponse = await fetch(
-      `${this.url}/users?${new URLSearchParams({
-        name: username,
-      })}`,
-      {
-        credentials: 'include',
-      }
-    );
     const apiUser: ApiUser = await apiUserResponse.json();
+    this.user = apiUser;
+
     const user: User = {
       username: apiUser.username,
+      role: undefined, // TODO: change role to roles
+      course: apiUser.registration_key?.key,
+      createdAt: new Date(apiUser.created_at),
+      lastSeen: new Date(apiUser.last_login),
     };
-
     return user;
   }
 
@@ -76,19 +118,41 @@ export class LighthouseAuthApi implements AuthApi {
       method: 'POST',
       credentials: 'include',
     });
-
     return true;
   }
 
   async getPublicUsers(): Promise<User[]> {
-    throw new Error('Method not implemented.');
+    // TODO: we currently don't have the concept of public users in the new API (heimdall)
+    return this.getAllUsers();
   }
 
   async getAllUsers(): Promise<User[]> {
-    throw new Error('Method not implemented.');
+    const apiUsersResponse = await fetch(`${this.url}/users`, {
+      credentials: 'include',
+    });
+    const apiUsers: ApiUser[] = await apiUsersResponse.json()
+    const users: User[] = apiUsers.map(apiUser => {
+      const user: User = {
+        username: apiUser.username,
+        role: undefined, // TODO: change role to roles
+        course: apiUser.registration_key?.key,
+        createdAt: new Date(apiUser.created_at),
+        lastSeen: new Date(apiUser.last_login),
+      };
+      return user;
+    });
+    return users;
   }
 
   async getToken(): Promise<Token | null> {
-    throw new Error('Method not implemented.');
+    const apiTokenResponse = await fetch(`${this.url}/users/${this.user?.id}/api-token`, {
+      credentials: 'include',
+    });
+    const apiToken: ApiToken = await apiTokenResponse.json();
+    const token: Token = {
+      value: apiToken.api_token,
+      expiresAt: new Date(apiToken.expires_at),
+    };
+    return token;
   }
 }

--- a/src/api/auth/LighthouseAuthApi.ts
+++ b/src/api/auth/LighthouseAuthApi.ts
@@ -50,7 +50,7 @@ interface ApiRegistrationKey {
 }
 
 export class LighthouseAuthApi implements AuthApi {
-  private user?: ApiUser;
+  private apiUser?: ApiUser;
 
   constructor(
     private readonly url: string = 'https://lighthouse.uni-kiel.de/api'

--- a/src/api/auth/LighthouseAuthApi.ts
+++ b/src/api/auth/LighthouseAuthApi.ts
@@ -26,7 +26,7 @@ interface ApiUser {
 interface ApiToken {
   api_token: string;
   expires_at: string;
-  roles: [string];
+  roles: string[];
   username: string;
 }
 


### PR DESCRIPTION
I added the ApiToken, ApiRole and ApiRegistrationKey types and finished the implementation of signUp, logIn, logOut, getAllUsers and getToken for the new authentication API (heimdall).