### PR TITLE
Animate the sidebar collapses

### DIFF
--- a/src/components/RouteLink.tsx
+++ b/src/components/RouteLink.tsx
@@ -2,6 +2,7 @@ import { Button } from '@nextui-org/react';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { ReactNode, useCallback, useState } from 'react';
 import { NavLink } from 'react-router-dom';
+import { AnimatePresence, motion } from 'framer-motion';
 
 interface RouteLinkParams {
   icon: ReactNode;
@@ -53,7 +54,23 @@ export function RouteLink({
           </Button>
         ) : null}
       </NavLink>
-      {isExpanded ? <div className="ml-4">{children}</div> : null}
+      <AnimatePresence initial={isExpanded}>
+        {isExpanded ? (
+          <motion.div
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            variants={{
+              open: { opacity: 1, height: 'auto' },
+              collapsed: { opacity: 0, height: 0 },
+            }}
+            transition={{ duration: 0.2 }}
+            className="ml-4"
+          >
+            {children}
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
     </div>
   );
 }


### PR DESCRIPTION
This adds an animation to the sidebar (based on [this example](https://codesandbox.io/s/framer-motion-accordion-qx958)):

https://github.com/user-attachments/assets/1ea9d914-907b-4882-a3f9-93a4781886cd

Marked as a draft, since it still seems to be a bit buggy and occasionally trigger page refreshes, both in Chrome and Firefox (why does this happen?).