### PR TITLE
Add support for monitoring arbitrary properties visually

### DIFF
--- a/src/screens/home/admin/MonitorInspector.tsx
+++ b/src/screens/home/admin/MonitorInspector.tsx
@@ -1,32 +1,32 @@
 import { LampV2Metrics } from '@luna/contexts/api/model/types';
 import { FlatRoomV2Metrics } from '@luna/screens/home/admin/helpers/FlatRoomV2Metrics';
-import { MonitorFilter } from '@luna/screens/home/admin/helpers/MonitorFilter';
+import { MonitorCriterion } from '@luna/screens/home/admin/helpers/MonitorCriterion';
 import { MonitorInspectorLampsCard } from '@luna/screens/home/admin/MonitorInspectorLampsCard';
 import { MonitorInspectorRoomCard } from '@luna/screens/home/admin/MonitorInspectorRoomCard';
 
 export interface MonitorInspectorProps {
-  filter?: MonitorFilter;
-  setFilter: (filter?: MonitorFilter) => void;
+  criterion?: MonitorCriterion;
+  setCriterion: (criterion?: MonitorCriterion) => void;
   flatRoomMetrics?: FlatRoomV2Metrics;
   lampMetrics?: LampV2Metrics[];
 }
 
 export function MonitorInspector({
-  filter,
-  setFilter,
+  criterion,
+  setCriterion,
   flatRoomMetrics,
   lampMetrics,
 }: MonitorInspectorProps) {
   return (
     <div className="flex flex-col space-y-3">
       <MonitorInspectorRoomCard
-        filter={filter?.type === 'room' ? filter : undefined}
-        setFilter={setFilter}
+        criterion={criterion?.type === 'room' ? criterion : undefined}
+        setCriterion={setCriterion}
         metrics={flatRoomMetrics}
       />
       <MonitorInspectorLampsCard
-        filter={filter?.type === 'lamp' ? filter : undefined}
-        setFilter={setFilter}
+        criterion={criterion?.type === 'lamp' ? criterion : undefined}
+        setCriterion={setCriterion}
         metrics={lampMetrics ?? []}
       />
     </div>

--- a/src/screens/home/admin/MonitorInspector.tsx
+++ b/src/screens/home/admin/MonitorInspector.tsx
@@ -1,21 +1,34 @@
 import { LampV2Metrics } from '@luna/contexts/api/model/types';
 import { FlatRoomV2Metrics } from '@luna/screens/home/admin/helpers/FlatRoomV2Metrics';
+import { MonitorFilter } from '@luna/screens/home/admin/helpers/MonitorFilter';
 import { MonitorInspectorLampsCard } from '@luna/screens/home/admin/MonitorInspectorLampsCard';
 import { MonitorInspectorRoomCard } from '@luna/screens/home/admin/MonitorInspectorRoomCard';
 
 export interface MonitorInspectorProps {
+  filter: MonitorFilter;
+  setFilter: (filter: MonitorFilter) => void;
   flatRoomMetrics?: FlatRoomV2Metrics;
   lampMetrics?: LampV2Metrics[];
 }
 
 export function MonitorInspector({
+  filter,
+  setFilter,
   flatRoomMetrics,
   lampMetrics,
 }: MonitorInspectorProps) {
   return (
     <div className="flex flex-col space-y-3">
-      <MonitorInspectorRoomCard metrics={flatRoomMetrics} />
-      <MonitorInspectorLampsCard metrics={lampMetrics ?? []} />
+      <MonitorInspectorRoomCard
+        filter={filter.type === 'room' ? filter : undefined}
+        setFilter={setFilter}
+        metrics={flatRoomMetrics}
+      />
+      <MonitorInspectorLampsCard
+        filter={filter.type === 'lamp' ? filter : undefined}
+        setFilter={setFilter}
+        metrics={lampMetrics ?? []}
+      />
     </div>
   );
 }

--- a/src/screens/home/admin/MonitorInspector.tsx
+++ b/src/screens/home/admin/MonitorInspector.tsx
@@ -5,8 +5,8 @@ import { MonitorInspectorLampsCard } from '@luna/screens/home/admin/MonitorInspe
 import { MonitorInspectorRoomCard } from '@luna/screens/home/admin/MonitorInspectorRoomCard';
 
 export interface MonitorInspectorProps {
-  filter: MonitorFilter;
-  setFilter: (filter: MonitorFilter) => void;
+  filter?: MonitorFilter;
+  setFilter: (filter?: MonitorFilter) => void;
   flatRoomMetrics?: FlatRoomV2Metrics;
   lampMetrics?: LampV2Metrics[];
 }
@@ -20,12 +20,12 @@ export function MonitorInspector({
   return (
     <div className="flex flex-col space-y-3">
       <MonitorInspectorRoomCard
-        filter={filter.type === 'room' ? filter : undefined}
+        filter={filter?.type === 'room' ? filter : undefined}
         setFilter={setFilter}
         metrics={flatRoomMetrics}
       />
       <MonitorInspectorLampsCard
-        filter={filter.type === 'lamp' ? filter : undefined}
+        filter={filter?.type === 'lamp' ? filter : undefined}
         setFilter={setFilter}
         metrics={lampMetrics ?? []}
       />

--- a/src/screens/home/admin/MonitorInspectorLampsCard.tsx
+++ b/src/screens/home/admin/MonitorInspectorLampsCard.tsx
@@ -1,13 +1,13 @@
 import { TitledCard } from '@luna/components/TitledCard';
 import { LampV2Metrics } from '@luna/contexts/api/model/types';
-import { MonitorLampFilter } from '@luna/screens/home/admin/helpers/MonitorFilter';
+import { MonitorLampCriterion } from '@luna/screens/home/admin/helpers/MonitorCriterion';
 import { MonitorInspectorTable } from '@luna/screens/home/admin/MonitorInspectorTable';
 import { MonitorInspectorValue } from '@luna/screens/home/admin/MonitorInspectorValue';
 import { IconCheck, IconLamp } from '@tabler/icons-react';
 
 export interface MonitorInspectorLampsCardProps {
-  filter?: MonitorLampFilter;
-  setFilter: (filter?: MonitorLampFilter) => void;
+  criterion?: MonitorLampCriterion;
+  setCriterion: (criterion?: MonitorLampCriterion) => void;
   metrics: LampV2Metrics[];
 }
 
@@ -22,8 +22,8 @@ const names: { [Property in keyof LampV2Metrics]: string } = {
 };
 
 export function MonitorInspectorLampsCard({
-  filter,
-  setFilter,
+  criterion,
+  setCriterion,
   metrics,
 }: MonitorInspectorLampsCardProps) {
   return (
@@ -32,8 +32,10 @@ export function MonitorInspectorLampsCard({
         <MonitorInspectorTable
           metrics={metrics}
           names={names}
-          selection={filter?.key}
-          onSelect={key => setFilter(key ? { type: 'lamp', key } : undefined)}
+          selection={criterion?.key}
+          onSelect={key =>
+            setCriterion(key ? { type: 'lamp', key } : undefined)
+          }
           render={(value, prop) => (
             <MonitorInspectorLampValue value={value} prop={prop} />
           )}

--- a/src/screens/home/admin/MonitorInspectorLampsCard.tsx
+++ b/src/screens/home/admin/MonitorInspectorLampsCard.tsx
@@ -22,6 +22,8 @@ const names: { [Property in keyof LampV2Metrics]: string } = {
 };
 
 export function MonitorInspectorLampsCard({
+  filter,
+  setFilter,
   metrics,
 }: MonitorInspectorLampsCardProps) {
   return (
@@ -30,6 +32,8 @@ export function MonitorInspectorLampsCard({
         <MonitorInspectorTable
           metrics={metrics}
           names={names}
+          selection={filter?.key}
+          onSelect={key => setFilter(key ? { type: 'lamp', key } : undefined)}
           render={(value, prop) => (
             <MonitorInspectorLampValue value={value} prop={prop} />
           )}

--- a/src/screens/home/admin/MonitorInspectorLampsCard.tsx
+++ b/src/screens/home/admin/MonitorInspectorLampsCard.tsx
@@ -7,7 +7,7 @@ import { IconCheck, IconLamp } from '@tabler/icons-react';
 
 export interface MonitorInspectorLampsCardProps {
   filter?: MonitorLampFilter;
-  setFilter: (filter: MonitorLampFilter) => void;
+  setFilter: (filter?: MonitorLampFilter) => void;
   metrics: LampV2Metrics[];
 }
 

--- a/src/screens/home/admin/MonitorInspectorLampsCard.tsx
+++ b/src/screens/home/admin/MonitorInspectorLampsCard.tsx
@@ -1,10 +1,13 @@
 import { TitledCard } from '@luna/components/TitledCard';
 import { LampV2Metrics } from '@luna/contexts/api/model/types';
+import { MonitorLampFilter } from '@luna/screens/home/admin/helpers/MonitorFilter';
 import { MonitorInspectorTable } from '@luna/screens/home/admin/MonitorInspectorTable';
 import { MonitorInspectorValue } from '@luna/screens/home/admin/MonitorInspectorValue';
 import { IconCheck, IconLamp } from '@tabler/icons-react';
 
 export interface MonitorInspectorLampsCardProps {
+  filter?: MonitorLampFilter;
+  setFilter: (filter: MonitorLampFilter) => void;
   metrics: LampV2Metrics[];
 }
 

--- a/src/screens/home/admin/MonitorInspectorRoomCard.tsx
+++ b/src/screens/home/admin/MonitorInspectorRoomCard.tsx
@@ -8,7 +8,7 @@ import { useMemo, useState } from 'react';
 
 export interface MonitorInspectorRoomCardProps {
   filter?: MonitorRoomFilter;
-  setFilter: (filter: MonitorRoomFilter) => void;
+  setFilter: (filter?: MonitorRoomFilter) => void;
   metrics?: FlatRoomV2Metrics;
 }
 

--- a/src/screens/home/admin/MonitorInspectorRoomCard.tsx
+++ b/src/screens/home/admin/MonitorInspectorRoomCard.tsx
@@ -4,7 +4,7 @@ import { MonitorRoomFilter } from '@luna/screens/home/admin/helpers/MonitorFilte
 import { MonitorInspectorTable } from '@luna/screens/home/admin/MonitorInspectorTable';
 import { MonitorInspectorValue } from '@luna/screens/home/admin/MonitorInspectorValue';
 import { IconDoor } from '@tabler/icons-react';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 export interface MonitorInspectorRoomCardProps {
   filter?: MonitorRoomFilter;
@@ -40,9 +40,10 @@ const units: { [Property in keyof FlatRoomV2Metrics]?: string } = {
 };
 
 export function MonitorInspectorRoomCard({
+  filter,
+  setFilter,
   metrics,
 }: MonitorInspectorRoomCardProps) {
-  const [selection, setSelection] = useState<keyof FlatRoomV2Metrics>();
   const renderedMetrics = useMemo<FlatRoomV2Metrics[]>(
     () => (metrics ? [metrics] : []),
     [metrics]
@@ -54,8 +55,8 @@ export function MonitorInspectorRoomCard({
         <MonitorInspectorTable
           metrics={renderedMetrics}
           names={names}
-          selection={selection}
-          onSelect={setSelection}
+          selection={filter?.key}
+          onSelect={key => setFilter(key ? { type: 'room', key } : undefined)}
           render={(value, prop) => (
             <MonitorInspectorRoomValue value={value} prop={prop} />
           )}

--- a/src/screens/home/admin/MonitorInspectorRoomCard.tsx
+++ b/src/screens/home/admin/MonitorInspectorRoomCard.tsx
@@ -1,14 +1,14 @@
 import { TitledCard } from '@luna/components/TitledCard';
 import { FlatRoomV2Metrics } from '@luna/screens/home/admin/helpers/FlatRoomV2Metrics';
-import { MonitorRoomFilter } from '@luna/screens/home/admin/helpers/MonitorFilter';
+import { MonitorRoomCriterion } from '@luna/screens/home/admin/helpers/MonitorCriterion';
 import { MonitorInspectorTable } from '@luna/screens/home/admin/MonitorInspectorTable';
 import { MonitorInspectorValue } from '@luna/screens/home/admin/MonitorInspectorValue';
 import { IconDoor } from '@tabler/icons-react';
 import { useMemo } from 'react';
 
 export interface MonitorInspectorRoomCardProps {
-  filter?: MonitorRoomFilter;
-  setFilter: (filter?: MonitorRoomFilter) => void;
+  criterion?: MonitorRoomCriterion;
+  setCriterion: (criterion?: MonitorRoomCriterion) => void;
   metrics?: FlatRoomV2Metrics;
 }
 
@@ -40,8 +40,8 @@ const units: { [Property in keyof FlatRoomV2Metrics]?: string } = {
 };
 
 export function MonitorInspectorRoomCard({
-  filter,
-  setFilter,
+  criterion,
+  setCriterion,
   metrics,
 }: MonitorInspectorRoomCardProps) {
   const renderedMetrics = useMemo<FlatRoomV2Metrics[]>(
@@ -55,8 +55,10 @@ export function MonitorInspectorRoomCard({
         <MonitorInspectorTable
           metrics={renderedMetrics}
           names={names}
-          selection={filter?.key}
-          onSelect={key => setFilter(key ? { type: 'room', key } : undefined)}
+          selection={criterion?.key}
+          onSelect={key =>
+            setCriterion(key ? { type: 'room', key } : undefined)
+          }
           render={(value, prop) => (
             <MonitorInspectorRoomValue value={value} prop={prop} />
           )}

--- a/src/screens/home/admin/MonitorInspectorRoomCard.tsx
+++ b/src/screens/home/admin/MonitorInspectorRoomCard.tsx
@@ -1,11 +1,14 @@
 import { TitledCard } from '@luna/components/TitledCard';
 import { FlatRoomV2Metrics } from '@luna/screens/home/admin/helpers/FlatRoomV2Metrics';
+import { MonitorRoomFilter } from '@luna/screens/home/admin/helpers/MonitorFilter';
 import { MonitorInspectorTable } from '@luna/screens/home/admin/MonitorInspectorTable';
 import { MonitorInspectorValue } from '@luna/screens/home/admin/MonitorInspectorValue';
 import { IconDoor } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
 
 export interface MonitorInspectorRoomCardProps {
+  filter?: MonitorRoomFilter;
+  setFilter: (filter: MonitorRoomFilter) => void;
   metrics?: FlatRoomV2Metrics;
 }
 

--- a/src/screens/home/admin/MonitorView.tsx
+++ b/src/screens/home/admin/MonitorView.tsx
@@ -133,7 +133,17 @@ export function MonitorView() {
             case 'board_temperature':
             case 'core_temperature':
               return [rgb.BLUE, rgb.RED];
+            case 'responding':
+              return [rgb.GREEN, rgb.RED];
           }
+          break;
+        case 'lamp':
+          switch (filter.key) {
+            case 'responding':
+            case 'fuse_tripped':
+              return [rgb.GREEN, rgb.RED];
+          }
+          break;
       }
     }
     return [rgb.BLACK, rgb.RED, rgb.YELLOW, rgb.WHITE];

--- a/src/screens/home/admin/MonitorView.tsx
+++ b/src/screens/home/admin/MonitorView.tsx
@@ -4,6 +4,7 @@ import { LaserMetrics, RoomV2Metrics } from '@luna/contexts/api/model/types';
 import { Breakpoint, useBreakpoint } from '@luna/hooks/useBreakpoint';
 import { useEventListener } from '@luna/hooks/useEventListener';
 import { flattenRoomV2Metrics } from '@luna/screens/home/admin/helpers/FlatRoomV2Metrics';
+import { MonitorFilter } from '@luna/screens/home/admin/helpers/MonitorFilter';
 import { MonitorInspector } from '@luna/screens/home/admin/MonitorInspector';
 import { HomeContent } from '@luna/screens/home/HomeContent';
 import { throttle } from '@luna/utils/schedule';
@@ -58,6 +59,10 @@ export function MonitorView() {
 
   const [focusedRoom, setSelectedRoom] = useState<number>();
   const [hoveredRoom, setHoveredRoom] = useState<number>();
+  const [filter, setFilter] = useState<MonitorFilter>({
+    type: 'lamp',
+    key: 'responding',
+  });
 
   const getLatestMetrics = useCallback(async () => {
     // setMetrics(testMetrics); // TODO: change back from test data to fetched data
@@ -83,6 +88,17 @@ export function MonitorView() {
     () => roomMetrics.map(room => flattenRoomV2Metrics(room)),
     [roomMetrics]
   );
+
+  const filteredValues = useMemo(() => {
+    switch (filter.type) {
+      case 'room':
+        return flatRoomMetrics.map(room => room[filter.key]);
+      case 'lamp':
+        return roomMetrics.flatMap(room =>
+          room.lamp_metrics.map(lamp => lamp[filter.key])
+        );
+    }
+  }, [filter, flatRoomMetrics, roomMetrics]);
 
   // fill the frame with colors according to the metrics data
   const frame = useMemo(() => {

--- a/src/screens/home/admin/MonitorView.tsx
+++ b/src/screens/home/admin/MonitorView.tsx
@@ -56,10 +56,7 @@ export function MonitorView() {
 
   const [focusedRoom, setSelectedRoom] = useState<number>();
   const [hoveredRoom, setHoveredRoom] = useState<number>();
-  const [filter, setFilter] = useState<MonitorFilter>({
-    type: 'lamp',
-    key: 'responding',
-  });
+  const [filter, setFilter] = useState<MonitorFilter>();
 
   const getLatestMetrics = useCallback(async () => {
     // setMetrics(testMetrics); // TODO: change back from test data to fetched data
@@ -90,6 +87,7 @@ export function MonitorView() {
   );
 
   const filteredValues = useMemo(() => {
+    if (filter === undefined) return undefined;
     switch (filter.type) {
       case 'room':
         return flatRoomMetrics.map(room => room[filter.key]);

--- a/src/screens/home/admin/MonitorView.tsx
+++ b/src/screens/home/admin/MonitorView.tsx
@@ -13,11 +13,7 @@ import { Vec2 } from '@luna/utils/vec2';
 import { Button } from '@heroui/react';
 import { IconRefresh } from '@tabler/icons-react';
 import { Set } from 'immutable';
-import {
-  LIGHTHOUSE_COLOR_CHANNELS,
-  LIGHTHOUSE_COLS,
-  LIGHTHOUSE_FRAME_BYTES,
-} from 'nighthouse/browser';
+import { LIGHTHOUSE_COLS, LIGHTHOUSE_FRAME_BYTES } from 'nighthouse/browser';
 import {
   useCallback,
   useContext,

--- a/src/screens/home/admin/MonitorView.tsx
+++ b/src/screens/home/admin/MonitorView.tsx
@@ -81,7 +81,10 @@ export function MonitorView() {
   }, [getLatestMetrics]);
 
   const roomMetrics = useMemo(
-    () => (metrics?.rooms ?? []) as RoomV2Metrics[],
+    () =>
+      (metrics?.rooms ?? []).filter(
+        room => room.api_version === 2
+      ) as RoomV2Metrics[],
     [metrics?.rooms]
   );
 
@@ -109,7 +112,6 @@ export function MonitorView() {
     let windowIdx = 0;
     const parityDim = (c: rgb.Color) => rgb.scale(c, parity ? 1 : 0.6);
     for (const room of roomMetrics) {
-      if (room.api_version !== 2) continue;
       const lampCount = room.lamp_metrics.length;
       // controller works?
       if (room.controller_metrics.responding) {

--- a/src/screens/home/admin/MonitorView.tsx
+++ b/src/screens/home/admin/MonitorView.tsx
@@ -223,6 +223,8 @@ export function MonitorView() {
           className={isCompact ? '' : 'flex flex-row justify-end grow-0 w-1/3'}
         >
           <MonitorInspector
+            filter={filter}
+            setFilter={setFilter}
             flatRoomMetrics={focusedFlatRoomMetrics}
             lampMetrics={focusedLampMetrics}
           />

--- a/src/screens/home/admin/helpers/MonitorCriterion.ts
+++ b/src/screens/home/admin/helpers/MonitorCriterion.ts
@@ -1,14 +1,14 @@
 import { LampV2Metrics } from '@luna/contexts/api/model/types';
 import { FlatRoomV2Metrics } from '@luna/screens/home/admin/helpers/FlatRoomV2Metrics';
 
-export interface MonitorRoomFilter {
+export interface MonitorRoomCriterion {
   type: 'room';
   key: keyof FlatRoomV2Metrics;
 }
 
-export interface MonitorLampFilter {
+export interface MonitorLampCriterion {
   type: 'lamp';
   key: keyof LampV2Metrics;
 }
 
-export type MonitorFilter = MonitorRoomFilter | MonitorLampFilter;
+export type MonitorCriterion = MonitorRoomCriterion | MonitorLampCriterion;

--- a/src/screens/home/admin/helpers/MonitorFilter.ts
+++ b/src/screens/home/admin/helpers/MonitorFilter.ts
@@ -1,0 +1,14 @@
+import { LampV2Metrics } from '@luna/contexts/api/model/types';
+import { FlatRoomV2Metrics } from '@luna/screens/home/admin/helpers/FlatRoomV2Metrics';
+
+export interface MonitorRoomFilter {
+  type: 'room';
+  key: keyof FlatRoomV2Metrics;
+}
+
+export interface MonitorLampFilter {
+  type: 'lamp';
+  key: keyof LampV2Metrics;
+}
+
+export type MonitorFilter = MonitorRoomFilter | MonitorLampFilter;

--- a/src/utils/rgb.ts
+++ b/src/utils/rgb.ts
@@ -60,11 +60,29 @@ export function fillAt(
 
 /// Linearly interpolates between two colors.
 export function lerp(lhs: Color, rhs: Color, value: number): Color {
+  const clampedValue = Math.min(1, Math.max(0, value));
   return color(
-    (1 - value) * getRed(lhs) + value * getRed(rhs),
-    (1 - value) * getGreen(lhs) + value * getGreen(rhs),
-    (1 - value) * getBlue(lhs) + value * getBlue(rhs)
+    (1 - clampedValue) * getRed(lhs) + clampedValue * getRed(rhs),
+    (1 - clampedValue) * getGreen(lhs) + clampedValue * getGreen(rhs),
+    (1 - clampedValue) * getBlue(lhs) + clampedValue * getBlue(rhs)
   );
+}
+
+/// Linearly interpolates between multiple colors (e.g. a colormap).
+export function lerpMultiple(colors: Color[], value: number): Color {
+  if (colors.length === 0) {
+    throw new Error('Cannot interpolate between an empty array of colors!');
+  }
+  const position = value * colors.length;
+  const i = Math.floor(position);
+  if (i < 0) {
+    return colors[0];
+  }
+  if (i >= colors.length - 1) {
+    return colors[colors.length - 1];
+  }
+  const remainder = position - i;
+  return lerp(colors[i], colors[i + 1], remainder);
 }
 
 /// Scales the given color.

--- a/src/utils/rgb.ts
+++ b/src/utils/rgb.ts
@@ -1,0 +1,60 @@
+/// An RGB color represented as a 32-bit integer.
+export type RGBColor = number;
+
+export const BLACK: RGBColor = 0x000000;
+export const WHITE: RGBColor = 0xffffff;
+export const RED: RGBColor = 0xff0000;
+export const GREEN: RGBColor = 0x00ff00;
+export const BLUE: RGBColor = 0x0000ff;
+export const YELLOW: RGBColor = 0xffff00;
+export const CYAN: RGBColor = 0x00ffff;
+export const MAGENTA: RGBColor = 0xff00ff;
+
+/// Creates an RGB color from the given red, green and blue components (as bytes between 0-255).
+export function rgbColor(red: number, green: number, blue: number): number {
+  return (red << 16) | (green << 8) | blue;
+}
+
+/// Fetches the red component (a byte in the range 0-255).
+export function getRed(color: RGBColor): number {
+  return (color >> 16) & 0xff;
+}
+
+/// Fetches the green component (a byte in the range 0-255).
+export function getGreen(color: RGBColor): number {
+  return (color >> 8) & 0xff;
+}
+
+/// Fetches the blue component (a byte in the range 0-255).
+export function getBlue(color: RGBColor): number {
+  return color & 0xff;
+}
+
+/// Fetches the `i`th color in the given (interleaved) RGB buffer.
+export function getRGBColorAt(i: number, rgbBuffer: Uint8Array): RGBColor {
+  return (
+    (rgbBuffer[i * 3] << 16) |
+    (rgbBuffer[i * 3 + 1] << 8) |
+    rgbBuffer[i * 3 + 2]
+  );
+}
+
+/// Sets the `i`th color to the given value in the given (interleaved) RGB buffer.
+export function setRGBColorAt(
+  i: number,
+  color: RGBColor,
+  rgbBuffer: Uint8Array
+): void {
+  rgbBuffer[i * 3] = (color >> 16) & 0xff;
+  rgbBuffer[i * 3 + 1] = (color >> 8) & 0xff;
+  rgbBuffer[i * 3 + 2] = color & 0xff;
+}
+
+/// Linearly interpolates between two colors.
+export function lerp(lhs: RGBColor, rhs: RGBColor, value: number): RGBColor {
+  return rgbColor(
+    (1 - value) * getRed(lhs) + value * getRed(rhs),
+    (1 - value) * getGreen(lhs) + value * getGreen(rhs),
+    (1 - value) * getBlue(lhs) + value * getBlue(rhs)
+  );
+}

--- a/src/utils/rgb.ts
+++ b/src/utils/rgb.ts
@@ -46,6 +46,18 @@ export function setAt(i: number, color: Color, rgbBuffer: Uint8Array): void {
   rgbBuffer[i * 3 + 2] = color & 0xff;
 }
 
+/// Fills a range with the given value in the given (interleaved) RGB buffer.
+export function fillAt(
+  i: number,
+  length: number,
+  color: Color,
+  rgbBuffer: Uint8Array
+): void {
+  for (let di = 0; di < length; di++) {
+    setAt(i + di, color, rgbBuffer);
+  }
+}
+
 /// Linearly interpolates between two colors.
 export function lerp(lhs: Color, rhs: Color, value: number): Color {
   return color(
@@ -53,4 +65,9 @@ export function lerp(lhs: Color, rhs: Color, value: number): Color {
     (1 - value) * getGreen(lhs) + value * getGreen(rhs),
     (1 - value) * getBlue(lhs) + value * getBlue(rhs)
   );
+}
+
+/// Scales the given color.
+export function scale(c: Color, value: number): Color {
+  return color(value * getRed(c), value * getGreen(c), value * getBlue(c));
 }

--- a/src/utils/rgb.ts
+++ b/src/utils/rgb.ts
@@ -1,37 +1,37 @@
 /// An RGB color represented as a 32-bit integer.
-export type RGBColor = number;
+export type Color = number;
 
-export const BLACK: RGBColor = 0x000000;
-export const WHITE: RGBColor = 0xffffff;
-export const RED: RGBColor = 0xff0000;
-export const GREEN: RGBColor = 0x00ff00;
-export const BLUE: RGBColor = 0x0000ff;
-export const YELLOW: RGBColor = 0xffff00;
-export const CYAN: RGBColor = 0x00ffff;
-export const MAGENTA: RGBColor = 0xff00ff;
+export const BLACK: Color = 0x000000;
+export const WHITE: Color = 0xffffff;
+export const RED: Color = 0xff0000;
+export const GREEN: Color = 0x00ff00;
+export const BLUE: Color = 0x0000ff;
+export const YELLOW: Color = 0xffff00;
+export const CYAN: Color = 0x00ffff;
+export const MAGENTA: Color = 0xff00ff;
 
 /// Creates an RGB color from the given red, green and blue components (as bytes between 0-255).
-export function rgbColor(red: number, green: number, blue: number): number {
+export function color(red: number, green: number, blue: number): number {
   return (red << 16) | (green << 8) | blue;
 }
 
 /// Fetches the red component (a byte in the range 0-255).
-export function getRed(color: RGBColor): number {
+export function getRed(color: Color): number {
   return (color >> 16) & 0xff;
 }
 
 /// Fetches the green component (a byte in the range 0-255).
-export function getGreen(color: RGBColor): number {
+export function getGreen(color: Color): number {
   return (color >> 8) & 0xff;
 }
 
 /// Fetches the blue component (a byte in the range 0-255).
-export function getBlue(color: RGBColor): number {
+export function getBlue(color: Color): number {
   return color & 0xff;
 }
 
 /// Fetches the `i`th color in the given (interleaved) RGB buffer.
-export function getRGBColorAt(i: number, rgbBuffer: Uint8Array): RGBColor {
+export function getAt(i: number, rgbBuffer: Uint8Array): Color {
   return (
     (rgbBuffer[i * 3] << 16) |
     (rgbBuffer[i * 3 + 1] << 8) |
@@ -40,19 +40,15 @@ export function getRGBColorAt(i: number, rgbBuffer: Uint8Array): RGBColor {
 }
 
 /// Sets the `i`th color to the given value in the given (interleaved) RGB buffer.
-export function setRGBColorAt(
-  i: number,
-  color: RGBColor,
-  rgbBuffer: Uint8Array
-): void {
+export function setAt(i: number, color: Color, rgbBuffer: Uint8Array): void {
   rgbBuffer[i * 3] = (color >> 16) & 0xff;
   rgbBuffer[i * 3 + 1] = (color >> 8) & 0xff;
   rgbBuffer[i * 3 + 2] = color & 0xff;
 }
 
 /// Linearly interpolates between two colors.
-export function lerp(lhs: RGBColor, rhs: RGBColor, value: number): RGBColor {
-  return rgbColor(
+export function lerp(lhs: Color, rhs: Color, value: number): Color {
+  return color(
     (1 - value) * getRed(lhs) + value * getRed(rhs),
     (1 - value) * getGreen(lhs) + value * getGreen(rhs),
     (1 - value) * getBlue(lhs) + value * getBlue(rhs)


### PR DESCRIPTION
As initially suggested in #5, this adds support for monitoring arbitrary quantities visually:

https://github.com/user-attachments/assets/b348c570-dfdf-4a17-bcb7-2109297469ba

### To do

- [x] Add `MonitorCriterion` type for representing the quantity monitored
- [x] Actually use this criterion in `MonitorView`
  - [x] Investigate whether we need support for different color schemes
  - [x] Investigate whether we need to declare the ranges of each quantity of if simple normalization across all observed values suffices
    - We'll use simple normalization (ignoring `null` or `undefined` values) for now
- [x] Bind the criterion to the table selection in the inspector cards