### PR TITLE
Bump nighthouse to 3.0.3 and pin it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@testing-library/user-event": "^14.5.2",
         "framer-motion": "^11",
         "immutable": "^4.3.6",
-        "nighthouse": "^3.0.2",
+        "nighthouse": "3.0.3",
         "react": "^18.3.1",
         "react-card-flip": "^1.2.3",
         "react-dom": "^18.3.1",
@@ -20092,9 +20092,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/nighthouse": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/nighthouse/-/nighthouse-3.0.2.tgz",
-      "integrity": "sha512-X/5MPdvOGMMe6E6yabdgn3xLA48uGvXK9pZS3nNLc9c6vzp/qIyiARKjf+6ATfknLUJ5OqPWpG8FYw1pUaZw8Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/nighthouse/-/nighthouse-3.0.3.tgz",
+      "integrity": "sha512-Xdf05MpHYUvKRy2Fc8iuX1UasMir7SyzZkwuqVMI0cYmZoCu943BbZkYb6EOiGF+KU5VNNpkyU+6NdPcjsV3+g==",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2"
       },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@testing-library/user-event": "^14.5.2",
     "framer-motion": "^11",
     "immutable": "^4.3.6",
-    "nighthouse": "^3.0.2",
+    "nighthouse": "3.0.3",
     "react": "^18.3.1",
     "react-card-flip": "^1.2.3",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
This removes the metrics types upstream and possibly (?) addresses #61.