### PR TITLE
Improve resource context menu

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -23,7 +23,7 @@ export function ContextMenu({ menu, children }: ContextMenuProps) {
     return () => {
       div.removeEventListener('contextmenu', listener);
     };
-  }, [divRef]);
+  }, []);
 
   return (
     <div ref={divRef}>

--- a/src/screens/home/admin/ResourcesTreeView.tsx
+++ b/src/screens/home/admin/ResourcesTreeView.tsx
@@ -258,10 +258,11 @@ function ResourcesTreeButton({
         console.log('Moving to', newPath);
         await model.move(path, newPath);
         await refreshListing();
+        setExpanded(newName);
       }
       setRenaming(false);
     },
-    [model, path, refreshListing, isResource]
+    [isResource, path, model, refreshListing, setExpanded]
   );
 
   return (

--- a/src/screens/home/admin/ResourcesTreeView.tsx
+++ b/src/screens/home/admin/ResourcesTreeView.tsx
@@ -217,7 +217,7 @@ function ResourcesTreeButton({
   const name = useMemo(() => path[path.length - 1], [path]);
   const isExpanded = useMemo(() => expanded === name, [expanded, name]);
 
-  const supportsRenaming = useMemo(() => subTree === null, [subTree]);
+  const isResource = useMemo(() => subTree === null, [subTree]);
 
   const color = useMemo(
     () => (isExpanded && layout === 'column' ? 'primary' : 'default'),
@@ -253,7 +253,7 @@ function ResourcesTreeButton({
 
   const renamePath = useCallback(
     async (newName: string) => {
-      if (supportsRenaming) {
+      if (isResource) {
         const newPath = [...path.slice(0, -1), newName];
         console.log('Moving to', newPath);
         await model.move(path, newPath);
@@ -261,21 +261,23 @@ function ResourcesTreeButton({
       }
       setRenaming(false);
     },
-    [model, path, refreshListing, supportsRenaming]
+    [model, path, refreshListing, isResource]
   );
 
   return (
     <ContextMenu
       menu={
         <DropdownMenu>
-          {supportsRenaming ? (
-            <DropdownItem key="rename" onPress={openRename}>
-              Rename
-            </DropdownItem>
+          {isResource ? (
+            <>
+              <DropdownItem key="rename" onPress={openRename}>
+                Rename
+              </DropdownItem>
+              <DropdownItem key="download" onPress={downloadPath}>
+                Download
+              </DropdownItem>
+            </>
           ) : null}
-          <DropdownItem key="download" onPress={downloadPath}>
-            Download
-          </DropdownItem>
           <DropdownItem
             key="delete"
             className="text-danger"

--- a/src/screens/home/admin/ResourcesTreeView.tsx
+++ b/src/screens/home/admin/ResourcesTreeView.tsx
@@ -311,7 +311,7 @@ function ResourcesTreeButton({
       </Button>
       <Modal isOpen={isRenaming} onOpenChange={setRenaming}>
         <ModalContent>
-          <ModalHeader>Rename {name}...</ModalHeader>
+          <ModalHeader>Rename Resource...</ModalHeader>
           <ModalBody>
             <SimpleEditForm initialValue={name} onSubmit={renamePath} />
           </ModalBody>

--- a/src/screens/home/admin/ResourcesTreeView.tsx
+++ b/src/screens/home/admin/ResourcesTreeView.tsx
@@ -249,7 +249,8 @@ function ResourcesTreeButton({
   const deletePath = useCallback(async () => {
     await model.delete(path);
     await refreshListing();
-  }, [model, path, refreshListing]);
+    setExpanded(undefined);
+  }, [model, path, refreshListing, setExpanded]);
 
   const renamePath = useCallback(
     async (newName: string) => {

--- a/src/screens/home/admin/ResourcesTreeView.tsx
+++ b/src/screens/home/admin/ResourcesTreeView.tsx
@@ -1,11 +1,13 @@
 import {
   Button,
+  Code,
   Divider,
   DropdownItem,
   DropdownMenu,
   Modal,
   ModalBody,
   ModalContent,
+  ModalFooter,
   ModalHeader,
   Popover,
   PopoverContent,
@@ -212,11 +214,12 @@ function ResourcesTreeButton({
   refreshListing: () => Promise<void>;
 }) {
   const model = useContext(ModelContext);
+
+  const [isDeleting, setDeleting] = useState(false);
   const [isRenaming, setRenaming] = useState(false);
 
   const name = useMemo(() => path[path.length - 1], [path]);
   const isExpanded = useMemo(() => expanded === name, [expanded, name]);
-
   const isResource = useMemo(() => subTree === null, [subTree]);
 
   const color = useMemo(
@@ -228,7 +231,9 @@ function ResourcesTreeButton({
     setExpanded(isExpanded ? undefined : name);
   }, [name, isExpanded, setExpanded]);
 
-  const openRename = useCallback(() => setRenaming(true), []);
+  const openDeleteModal = useCallback(() => setDeleting(true), []);
+  const closeDeleteModal = useCallback(() => setDeleting(false), []);
+  const openRenameModal = useCallback(() => setRenaming(true), []);
 
   const downloadPath = useCallback(async () => {
     const result = await model.get(path);
@@ -276,7 +281,7 @@ function ResourcesTreeButton({
         <DropdownMenu>
           {isResource ? (
             <>
-              <DropdownItem key="rename" onPress={openRename}>
+              <DropdownItem key="rename" onPress={openRenameModal}>
                 Rename
               </DropdownItem>
               <DropdownItem key="download" onPress={downloadPath}>
@@ -288,7 +293,7 @@ function ResourcesTreeButton({
             key="delete"
             className="text-danger"
             color="danger"
-            onPress={deletePath}
+            onPress={openDeleteModal}
           >
             Delete
           </DropdownItem>
@@ -315,10 +320,24 @@ function ResourcesTreeButton({
       </Button>
       <Modal isOpen={isRenaming} onOpenChange={setRenaming}>
         <ModalContent>
-          <ModalHeader>Rename Resource...</ModalHeader>
+          <ModalHeader>Rename {name}...</ModalHeader>
           <ModalBody>
             <SimpleEditForm initialValue={name} onSubmit={renamePath} />
           </ModalBody>
+        </ModalContent>
+      </Modal>
+      <Modal isOpen={isDeleting} onOpenChange={setDeleting}>
+        <ModalContent>
+          <ModalHeader>Delete {name}...</ModalHeader>
+          <ModalBody>
+            Are you sure that you wish to delete {path.join('/')}?
+          </ModalBody>
+          <ModalFooter>
+            <Button color="danger" onPress={deletePath}>
+              Delete {name}
+            </Button>
+            <Button onPress={closeDeleteModal}>Cancel</Button>
+          </ModalFooter>
         </ModalContent>
       </Modal>
     </ContextMenu>

--- a/src/screens/home/admin/ResourcesTreeView.tsx
+++ b/src/screens/home/admin/ResourcesTreeView.tsx
@@ -221,6 +221,22 @@ function ResourcesTreeButton({
     setExpanded(isExpanded ? undefined : name);
   }, [name, isExpanded, setExpanded]);
 
+  const downloadPath = useCallback(async () => {
+    const result = await model.get(path);
+    if (result.ok) {
+      const json = JSON.stringify(result.value, null, 2);
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+
+      const a = document.createElement('a');
+      a.download = `${name}.json`;
+      a.href = url;
+      a.click();
+    } else {
+      console.log(result.error);
+    }
+  }, [model, name, path]);
+
   const deletePath = useCallback(async () => {
     await model.delete(path);
     refreshListing();
@@ -230,6 +246,9 @@ function ResourcesTreeButton({
     <ContextMenu
       menu={
         <DropdownMenu>
+          <DropdownItem key="download" onPress={downloadPath}>
+            Download
+          </DropdownItem>
           <DropdownItem
             key="delete"
             className="text-danger"

--- a/src/screens/home/admin/ResourcesTreeView.tsx
+++ b/src/screens/home/admin/ResourcesTreeView.tsx
@@ -249,8 +249,10 @@ function ResourcesTreeButton({
   const deletePath = useCallback(async () => {
     await model.delete(path);
     await refreshListing();
-    setExpanded(undefined);
-  }, [model, path, refreshListing, setExpanded]);
+    if (isExpanded) {
+      setExpanded(undefined);
+    }
+  }, [isExpanded, model, path, refreshListing, setExpanded]);
 
   const renamePath = useCallback(
     async (newName: string) => {
@@ -259,11 +261,13 @@ function ResourcesTreeButton({
         console.log('Moving to', newPath);
         await model.move(path, newPath);
         await refreshListing();
-        setExpanded(newName);
+        if (isExpanded) {
+          setExpanded(newName);
+        }
       }
       setRenaming(false);
     },
-    [isResource, path, model, refreshListing, setExpanded]
+    [isResource, path, model, refreshListing, isExpanded, setExpanded]
   );
 
   return (


### PR DESCRIPTION
This improves the resource context menu by adding the option to download the resource as a JSON file and to rename it:

![Screenshot 2025-02-27 at 23 16 50](https://github.com/user-attachments/assets/b62ff17f-8555-4d93-8836-14469a0d0cf8)

Additionally, deletions must now be confirmed via a modal to avoid accidental deletions (potentially of entire directory trees):

![Screenshot 2025-02-27 at 23 17 25](https://github.com/user-attachments/assets/884f2270-00d2-47fc-8671-e76fe9e05f17)
