### PR TITLE
Fix mouse coordinate conversion on high DPI displays

### DIFF
--- a/src/components/Display.tsx
+++ b/src/components/Display.tsx
@@ -127,7 +127,13 @@ export function Display({
 
     const eventToMouseCoords = (event: MouseEvent) => {
       const rect = canvas.getBoundingClientRect();
-      return { x: event.clientX - rect.left, y: event.clientY - rect.top };
+      return {
+        x:
+          ((event.clientX - rect.left) / (rect.right - rect.left)) *
+          canvas.width,
+        y:
+          event.clientY - (rect.top / (rect.bottom - rect.top)) * canvas.height,
+      };
     };
 
     const clampToNormalizedRange = (x: number) =>


### PR DESCRIPTION
This fixes the mouse coordinate conversion in `Display` on high-DPI displays (e.g. modern phones), see https://stackoverflow.com/a/33063222.