### PR TITLE
Bump nighthouse to 4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@testing-library/user-event": "^14.5.2",
         "framer-motion": "^11",
         "immutable": "^4.3.6",
-        "nighthouse": "4.1.0",
+        "nighthouse": "4.2.0",
         "react": "^18.3.1",
         "react-card-flip": "^1.2.3",
         "react-dom": "^18.3.1",
@@ -20092,9 +20092,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/nighthouse": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/nighthouse/-/nighthouse-4.1.0.tgz",
-      "integrity": "sha512-ytwzdSCBPXA5SLqh1DKRjKm/3ls2EbmCPXYPsdGYlKBSyO9JZvFZlYyiI4YSQ8nKOUxkXN//Op4ErI7OJdqpVQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/nighthouse/-/nighthouse-4.2.0.tgz",
+      "integrity": "sha512-VHIcsnma7u6hPXmhvDl2E2PSgbcGpuLez7tiuiOUPMewIZH1JKW9b8pRWYuOtuW1rAB1GyXCoc2kYqh8BUnruA==",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2"
       },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@testing-library/user-event": "^14.5.2",
     "framer-motion": "^11",
     "immutable": "^4.3.6",
-    "nighthouse": "4.1.0",
+    "nighthouse": "4.2.0",
     "react": "^18.3.1",
     "react-card-flip": "^1.2.3",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
Nighthouse 4.2.0 removes client-side demultiplexing in favor of having the server handle streams on the same resource.