### PR TITLE
Add quick switcher (and factor out useVisibleRoutes hook)

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,12 +1,14 @@
 import { useDebounce } from '@luna/hooks/useDebounce';
-import { Input } from '@heroui/react';
+import { Input, Tooltip } from '@heroui/react';
 import { IconSearch } from '@tabler/icons-react';
-import { useCallback, useState } from 'react';
+import { ReactNode, useCallback, useState } from 'react';
 
 export interface SearchBarProps {
   placeholder?: string;
   fullWidth?: boolean;
   className?: string;
+  tooltip?: ReactNode;
+  tooltipPlacement?: 'top' | 'bottom' | 'left' | 'right';
   setQuery: (query: string) => void;
 }
 
@@ -14,6 +16,8 @@ export function SearchBar({
   placeholder,
   fullWidth,
   className = '',
+  tooltip,
+  tooltipPlacement,
   setQuery,
 }: SearchBarProps) {
   const [value, setValue] = useState('');
@@ -30,7 +34,7 @@ export function SearchBar({
 
   const clearQuery = useCallback(() => onValueChange(''), [onValueChange]);
 
-  return (
+  const input = (
     <Input
       startContent={<IconSearch />}
       placeholder={placeholder}
@@ -39,5 +43,13 @@ export function SearchBar({
       onValueChange={onValueChange}
       onClear={clearQuery}
     />
+  );
+
+  return tooltip ? (
+    <Tooltip content={tooltip} placement={tooltipPlacement}>
+      {input}
+    </Tooltip>
+  ) : (
+    input
   );
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -45,11 +45,13 @@ export function SearchBar({
     />
   );
 
-  return tooltip ? (
-    <Tooltip content={tooltip} placement={tooltipPlacement}>
+  return (
+    <Tooltip
+      content={tooltip}
+      placement={tooltipPlacement}
+      isDisabled={tooltip === undefined}
+    >
       {input}
     </Tooltip>
-  ) : (
-    input
   );
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -31,15 +31,13 @@ export function SearchBar({
   const clearQuery = useCallback(() => onValueChange(''), [onValueChange]);
 
   return (
-    // TODO: Pass fullWidth directly to <Input> once https://github.com/nextui-org/nextui/pull/3768 is released
-    <div className={`${fullWidth ? '' : 'max-w-60'} ${className}`}>
-      <Input
-        startContent={<IconSearch />}
-        placeholder={placeholder}
-        value={value}
-        onValueChange={onValueChange}
-        onClear={clearQuery}
-      />
-    </div>
+    <Input
+      startContent={<IconSearch />}
+      placeholder={placeholder}
+      value={value}
+      fullWidth
+      onValueChange={onValueChange}
+      onClear={clearQuery}
+    />
   );
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -35,14 +35,15 @@ export function SearchBar({
   const clearQuery = useCallback(() => onValueChange(''), [onValueChange]);
 
   const input = (
-    <Input
-      startContent={<IconSearch />}
-      placeholder={placeholder}
-      value={value}
-      fullWidth
-      onValueChange={onValueChange}
-      onClear={clearQuery}
-    />
+    <div className={`${fullWidth ? '' : 'max-w-60'} ${className}`}>
+      <Input
+        startContent={<IconSearch />}
+        placeholder={placeholder}
+        value={value}
+        onValueChange={onValueChange}
+        onClear={clearQuery}
+      />
+    </div>
   );
 
   return (

--- a/src/hooks/useVisibleRoutes.tsx
+++ b/src/hooks/useVisibleRoutes.tsx
@@ -114,8 +114,10 @@ export function useVisibleRoutes({
     [allUsernames, searchQuery, showUserDisplays, user?.username]
   );
 
-  return useMemo<VisibleRoute[]>(
+  const routes = useMemo<VisibleRoute[]>(
     () => [...(isAdmin ? adminRoutes : []), ...userRoutes],
     [adminRoutes, isAdmin, userRoutes]
   );
+
+  return routes;
 }

--- a/src/hooks/useVisibleRoutes.tsx
+++ b/src/hooks/useVisibleRoutes.tsx
@@ -93,8 +93,18 @@ export function useVisibleRoutes({
         name: 'Displays',
         path: '/displays',
         icon: <IconBuildingLighthouse />,
-        children:
-          showUserDisplays || searchQuery
+        children: [
+          ...(user?.username
+            ? [
+                {
+                  name: `${user.username} (me)`,
+                  icon: <IconBuildingLighthouse />,
+                  path: `/displays/${user.username}`,
+                  children: [],
+                },
+              ]
+            : []),
+          ...(showUserDisplays || searchQuery
             ? allUsernames
                 .filter(
                   username =>
@@ -108,7 +118,8 @@ export function useVisibleRoutes({
                   icon: <IconBuildingLighthouse />,
                   children: [],
                 }))
-            : [],
+            : []),
+        ],
       },
     ],
     [allUsernames, searchQuery, showUserDisplays, user?.username]

--- a/src/hooks/useVisibleRoutes.tsx
+++ b/src/hooks/useVisibleRoutes.tsx
@@ -1,0 +1,121 @@
+import { AuthContext } from '@luna/contexts/api/auth/AuthContext';
+import { ModelContext } from '@luna/contexts/api/model/ModelContext';
+import { useJsonMemo } from '@luna/hooks/useJsonMemo';
+import {
+  IconBuildingLighthouse,
+  IconCategory,
+  IconFolder,
+  IconHeartRateMonitor,
+  IconKey,
+  IconSettings,
+  IconTower,
+  IconUsers,
+} from '@tabler/icons-react';
+import { ReactNode, useContext, useMemo } from 'react';
+
+export interface VisibleRoute {
+  name: string;
+  path: string;
+  icon: ReactNode;
+  children: VisibleRoute[];
+}
+
+export function useVisibleRoutes({
+  showUserDisplays = true,
+  searchQuery = '',
+}: {
+  showUserDisplays?: boolean;
+  searchQuery?: string;
+}) {
+  const { users } = useContext(ModelContext);
+  const auth = useContext(AuthContext);
+
+  const user = useMemo(() => auth.user, [auth.user]);
+  const isAdmin = useMemo(
+    () => user?.roles.find(role => role.name === 'admin') !== undefined,
+    [user?.roles]
+  );
+
+  const adminRoutes = useMemo(
+    () => [
+      {
+        name: 'Admin',
+        path: '/admin',
+        icon: <IconTower />,
+        children: [
+          {
+            name: 'Resources',
+            path: '/admin/resources',
+            icon: <IconFolder />,
+            children: [],
+          },
+          {
+            name: 'Monitoring',
+            path: '/admin/monitoring',
+            icon: <IconHeartRateMonitor />,
+            children: [],
+          },
+          {
+            name: 'Users',
+            path: '/admin/users',
+            icon: <IconUsers />,
+            children: [],
+          },
+          {
+            name: 'Roles',
+            path: '/admin/roles',
+            icon: <IconCategory />,
+            children: [],
+          },
+          {
+            name: 'Registration Keys',
+            path: '/admin/registration-keys',
+            icon: <IconKey />,
+            children: [],
+          },
+          {
+            name: 'Settings',
+            path: '/admin/settings',
+            icon: <IconSettings />,
+            children: [],
+          },
+        ],
+      },
+    ],
+    []
+  );
+
+  const allUsernames = useJsonMemo([...users.all]);
+
+  const userRoutes = useMemo(
+    () => [
+      {
+        name: 'Displays',
+        path: '/displays',
+        icon: <IconBuildingLighthouse />,
+        children:
+          showUserDisplays || searchQuery
+            ? allUsernames
+                .filter(
+                  username =>
+                    username !== user?.username &&
+                    username.toLowerCase().includes(searchQuery.toLowerCase())
+                )
+                .sort()
+                .map<VisibleRoute>(username => ({
+                  name: username,
+                  path: `/displays/${username}`,
+                  icon: <IconBuildingLighthouse />,
+                  children: [],
+                }))
+            : [],
+      },
+    ],
+    [allUsernames, searchQuery, showUserDisplays, user?.username]
+  );
+
+  return useMemo<VisibleRoute[]>(
+    () => [...(isAdmin ? adminRoutes : []), ...userRoutes],
+    [adminRoutes, isAdmin, userRoutes]
+  );
+}

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -1,20 +1,55 @@
 import { Input, Modal, ModalContent } from '@heroui/react';
+import { useVisibleRoutes, VisibleRoute } from '@luna/hooks/useVisibleRoutes';
+import { useMemo, useState } from 'react';
 
 export interface QuickSwitcherModalProps {
   isOpen: boolean;
   setOpen: (show: boolean) => void;
 }
 
+function flatten(routes: VisibleRoute[]): VisibleRoute[] {
+  return routes.flatMap(route => [route, ...flatten(route.children)]);
+}
+
 export function QuickSwitcherModal({
   isOpen,
   setOpen,
 }: QuickSwitcherModalProps) {
+  const [query, setQuery] = useState('');
+
+  const visibleRoutes = useVisibleRoutes({});
+  const flatRoutes = useMemo(() => flatten(visibleRoutes), [visibleRoutes]);
+
+  const filteredRoutes = useMemo(() => {
+    const lowerQuery = query.toLowerCase();
+    return flatRoutes
+      .filter(route => route.name.toLowerCase().includes(lowerQuery))
+      .slice(0, 8);
+  }, [flatRoutes, query]);
+
   return (
     <Modal isOpen={isOpen} onOpenChange={setOpen}>
       <ModalContent>
         {onClose => (
           <div className="flex flex-col">
-            <Input autoFocus placeholder="Where do you want to go?" />
+            <Input
+              autoFocus
+              placeholder="Where do you want to go?"
+              value={query}
+              onValueChange={setQuery}
+            />
+            {query ? (
+              <div className="p-3">
+                {filteredRoutes.map(route => (
+                  <div
+                    key={JSON.stringify(route.path)}
+                    className="flex flex-row gap-1"
+                  >
+                    {route.icon} {route.name}
+                  </div>
+                ))}
+              </div>
+            ) : null}
           </div>
         )}
       </ModalContent>

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -46,7 +46,7 @@ export function QuickSwitcherModal({
   }, [isOpen]);
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={setOpen}>
+    <Modal isOpen={isOpen} onOpenChange={setOpen} placement="top">
       <ModalContent>
         {onClose => (
           <div className="flex flex-col">

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -13,10 +13,15 @@ function flatten(
   routes: VisibleRoute[],
   parentNames: string[] = []
 ): (VisibleRoute & { parentNames: string[] })[] {
-  return routes.flatMap(route => [
-    { ...route, parentNames },
-    ...flatten(route.children, [...parentNames, route.name]),
-  ]);
+  return (
+    routes
+      .flatMap(route => [
+        { ...route, parentNames },
+        ...flatten(route.children, [...parentNames, route.name]),
+      ])
+      // Prioritize longer paths
+      .sort((a, b) => b.path.length - a.path.length)
+  );
 }
 
 export function QuickSwitcherModal({

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -1,11 +1,4 @@
-import {
-  Input,
-  Listbox,
-  ListboxItem,
-  Modal,
-  ModalContent,
-  Skeleton,
-} from '@heroui/react';
+import { Input, Modal, ModalContent, Skeleton } from '@heroui/react';
 import { useVisibleRoutes, VisibleRoute } from '@luna/hooks/useVisibleRoutes';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { NavLink } from 'react-router-dom';

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -27,6 +27,7 @@ export function QuickSwitcherModal({
   const flatRoutes = useMemo(() => flatten(visibleRoutes), [visibleRoutes]);
 
   const filteredRoutes = useMemo(() => {
+    if (!query) return [];
     const lowerQuery = query.toLowerCase();
     return flatRoutes
       .filter(route => route.name.toLowerCase().includes(lowerQuery))
@@ -44,30 +45,29 @@ export function QuickSwitcherModal({
           <div className="flex flex-col">
             <Input
               autoFocus
+              variant="faded"
               placeholder="Where do you want to go?"
               value={query}
               onValueChange={setQuery}
+              classNames={{
+                // Remove focus ring: https://dev.to/janjitsu/remove-ring-border-from-nextui-input-component-11h1
+                inputWrapper:
+                  'group-data-[focus-visible=true]:ring-0 group-data-[focus-visible=true]:ring-offset-0',
+              }}
             />
-            {query ? (
-              <Listbox
-                className="p-2"
-                items={filteredRoutes}
-                aria-label="Results"
-              >
-                {route => (
-                  <ListboxItem
-                    key={route.key}
-                    startContent={route.icon}
-                    aria-label={route.name}
-                  >
+            {filteredRoutes.length > 0 ? (
+              <div className="flex flex-col gap-2 p-2" aria-label="Results">
+                {filteredRoutes.map(route => (
+                  <div className="flex flex-row gap-2">
+                    {route.icon}
                     <div
                       className={route.key === selectedKey ? 'font-bold' : ''}
                     >
                       {route.name}
                     </div>
-                  </ListboxItem>
-                )}
-              </Listbox>
+                  </div>
+                ))}
+              </div>
             ) : null}
           </div>
         )}

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -1,0 +1,17 @@
+import { Modal, ModalContent } from '@heroui/react';
+
+export interface QuickSwitcherModalProps {
+  isOpen: boolean;
+  setOpen: (show: boolean) => void;
+}
+
+export function QuickSwitcherModal({
+  isOpen,
+  setOpen,
+}: QuickSwitcherModalProps) {
+  return (
+    <Modal isOpen={isOpen} onOpenChange={setOpen}>
+      <ModalContent>{onClose => <>TODO</>}</ModalContent>
+    </Modal>
+  );
+}

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -6,7 +6,8 @@ import {
   ModalContent,
 } from '@heroui/react';
 import { useVisibleRoutes, VisibleRoute } from '@luna/hooks/useVisibleRoutes';
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { NavLink } from 'react-router-dom';
 
 export interface QuickSwitcherModalProps {
   isOpen: boolean;
@@ -38,6 +39,16 @@ export function QuickSwitcherModal({
   const selectedKey =
     filteredRoutes.length > 0 ? filteredRoutes[0].key : undefined;
 
+  const close = useCallback(() => {
+    setOpen(false);
+  }, [setOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setQuery('');
+    }
+  }, [isOpen]);
+
   return (
     <Modal isOpen={isOpen} onOpenChange={setOpen}>
       <ModalContent>
@@ -58,14 +69,16 @@ export function QuickSwitcherModal({
             {filteredRoutes.length > 0 ? (
               <div className="flex flex-col gap-2 p-2" aria-label="Results">
                 {filteredRoutes.map(route => (
-                  <div className="flex flex-row gap-2">
-                    {route.icon}
-                    <div
-                      className={route.key === selectedKey ? 'font-bold' : ''}
-                    >
-                      {route.name}
+                  <NavLink to={route.path} key={route.key} onClick={close}>
+                    <div className="flex flex-row gap-2">
+                      {route.icon}
+                      <div
+                        className={route.key === selectedKey ? 'font-bold' : ''}
+                      >
+                        {route.name}
+                      </div>
                     </div>
-                  </div>
+                  </NavLink>
                 ))}
               </div>
             ) : null}

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -1,8 +1,8 @@
 import { Input, Modal, ModalContent, Skeleton } from '@heroui/react';
 import { useVisibleRoutes, VisibleRoute } from '@luna/hooks/useVisibleRoutes';
 import { IconChevronRight } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { NavLink } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { NavLink, useNavigate } from 'react-router-dom';
 
 export interface QuickSwitcherModalProps {
   isOpen: boolean;
@@ -24,6 +24,7 @@ export function QuickSwitcherModal({
   setOpen,
 }: QuickSwitcherModalProps) {
   const [query, setQuery] = useState('');
+  const navigate = useNavigate();
 
   const visibleRoutes = useVisibleRoutes({});
   const flatRoutes = useMemo(() => flatten(visibleRoutes), [visibleRoutes]);
@@ -39,8 +40,8 @@ export function QuickSwitcherModal({
       .slice(0, maxResults);
   }, [flatRoutes, query]);
 
-  const selectedKey =
-    filteredRoutes.length > 0 ? filteredRoutes[0].key : undefined;
+  const selectedRoute =
+    filteredRoutes.length > 0 ? filteredRoutes[0] : undefined;
 
   useEffect(() => {
     if (!isOpen) {
@@ -52,7 +53,16 @@ export function QuickSwitcherModal({
     <Modal isOpen={isOpen} onOpenChange={setOpen} placement="top">
       <ModalContent>
         {onClose => (
-          <div className="flex flex-col">
+          <form
+            className="flex flex-col"
+            onSubmit={e => {
+              if (selectedRoute) {
+                navigate(selectedRoute.path);
+                onClose();
+              }
+              e.preventDefault();
+            }}
+          >
             <Input
               autoFocus
               variant="faded"
@@ -71,7 +81,7 @@ export function QuickSwitcherModal({
                   route ? (
                     <NavLink to={route.path} key={route.key} onClick={onClose}>
                       <div
-                        className={`flex flex-row p-2 gap-2 items-center rounded-md ${route.key === selectedKey ? 'bg-primary' : ''}`}
+                        className={`flex flex-row p-2 gap-2 items-center rounded-md ${route.key === selectedRoute?.key ? 'bg-primary' : ''}`}
                       >
                         {route.icon}
                         <div className="flex flex-row items-center">
@@ -83,7 +93,9 @@ export function QuickSwitcherModal({
                           ))}
                           <div
                             className={
-                              route.key === selectedKey ? 'font-bold' : ''
+                              route.key === selectedRoute?.key
+                                ? 'font-bold'
+                                : ''
                             }
                           >
                             {route.name}
@@ -97,7 +109,7 @@ export function QuickSwitcherModal({
                 )}
               </div>
             ) : null}
-          </div>
+          </form>
         )}
       </ModalContent>
     </Modal>

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -1,4 +1,10 @@
-import { Input, Modal, ModalContent } from '@heroui/react';
+import {
+  Input,
+  Listbox,
+  ListboxItem,
+  Modal,
+  ModalContent,
+} from '@heroui/react';
 import { useVisibleRoutes, VisibleRoute } from '@luna/hooks/useVisibleRoutes';
 import { useMemo, useState } from 'react';
 
@@ -24,8 +30,12 @@ export function QuickSwitcherModal({
     const lowerQuery = query.toLowerCase();
     return flatRoutes
       .filter(route => route.name.toLowerCase().includes(lowerQuery))
+      .map(route => ({ ...route, key: JSON.stringify(route.path) }))
       .slice(0, 8);
   }, [flatRoutes, query]);
+
+  const selectedKey =
+    filteredRoutes.length > 0 ? filteredRoutes[0].key : undefined;
 
   return (
     <Modal isOpen={isOpen} onOpenChange={setOpen}>
@@ -39,16 +49,25 @@ export function QuickSwitcherModal({
               onValueChange={setQuery}
             />
             {query ? (
-              <div className="p-3">
-                {filteredRoutes.map(route => (
-                  <div
-                    key={JSON.stringify(route.path)}
-                    className="flex flex-row gap-1"
+              <Listbox
+                className="p-2"
+                items={filteredRoutes}
+                aria-label="Results"
+              >
+                {route => (
+                  <ListboxItem
+                    key={route.key}
+                    startContent={route.icon}
+                    aria-label={route.name}
                   >
-                    {route.icon} {route.name}
-                  </div>
-                ))}
-              </div>
+                    <div
+                      className={route.key === selectedKey ? 'font-bold' : ''}
+                    >
+                      {route.name}
+                    </div>
+                  </ListboxItem>
+                )}
+              </Listbox>
             ) : null}
           </div>
         )}

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, ModalContent } from '@heroui/react';
+import { Input, Modal, ModalContent } from '@heroui/react';
 
 export interface QuickSwitcherModalProps {
   isOpen: boolean;
@@ -11,7 +11,13 @@ export function QuickSwitcherModal({
 }: QuickSwitcherModalProps) {
   return (
     <Modal isOpen={isOpen} onOpenChange={setOpen}>
-      <ModalContent>{onClose => <>TODO</>}</ModalContent>
+      <ModalContent>
+        {onClose => (
+          <div className="flex flex-col">
+            <Input autoFocus placeholder="Where do you want to go?" />
+          </div>
+        )}
+      </ModalContent>
     </Modal>
   );
 }

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -42,10 +42,6 @@ export function QuickSwitcherModal({
   const selectedKey =
     filteredRoutes.length > 0 ? filteredRoutes[0].key : undefined;
 
-  const close = useCallback(() => {
-    setOpen(false);
-  }, [setOpen]);
-
   useEffect(() => {
     if (!isOpen) {
       setQuery('');
@@ -73,7 +69,7 @@ export function QuickSwitcherModal({
               <div className="flex flex-col gap-2 p-2" aria-label="Results">
                 {filteredRoutes.map(route =>
                   route ? (
-                    <NavLink to={route.path} key={route.key} onClick={close}>
+                    <NavLink to={route.path} key={route.key} onClick={onClose}>
                       <div
                         className={`flex flex-row p-2 gap-2 items-center rounded-md ${route.key === selectedKey ? 'bg-primary' : ''}`}
                       >

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -1,5 +1,6 @@
 import { Input, Modal, ModalContent, Skeleton } from '@heroui/react';
 import { useVisibleRoutes, VisibleRoute } from '@luna/hooks/useVisibleRoutes';
+import { IconChevronRight } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 
@@ -8,8 +9,14 @@ export interface QuickSwitcherModalProps {
   setOpen: (show: boolean) => void;
 }
 
-function flatten(routes: VisibleRoute[]): VisibleRoute[] {
-  return routes.flatMap(route => [route, ...flatten(route.children)]);
+function flatten(
+  routes: VisibleRoute[],
+  parentNames: string[] = []
+): (VisibleRoute & { parentNames: string[] })[] {
+  return routes.flatMap(route => [
+    { ...route, parentNames },
+    ...flatten(route.children, [...parentNames, route.name]),
+  ]);
 }
 
 export function QuickSwitcherModal({
@@ -68,15 +75,23 @@ export function QuickSwitcherModal({
                   route ? (
                     <NavLink to={route.path} key={route.key} onClick={close}>
                       <div
-                        className={`flex flex-row gap-2 p-2 rounded-md ${route.key === selectedKey ? 'bg-primary' : ''}`}
+                        className={`flex flex-row p-2 gap-2 items-center rounded-md ${route.key === selectedKey ? 'bg-primary' : ''}`}
                       >
                         {route.icon}
-                        <div
-                          className={
-                            route.key === selectedKey ? 'font-bold' : ''
-                          }
-                        >
-                          {route.name}
+                        <div className="flex flex-row items-center">
+                          {route.parentNames.map(name => (
+                            <div key={name} className="flex flex-row">
+                              {name}
+                              <IconChevronRight />
+                            </div>
+                          ))}
+                          <div
+                            className={
+                              route.key === selectedKey ? 'font-bold' : ''
+                            }
+                          >
+                            {route.name}
+                          </div>
                         </div>
                       </div>
                     </NavLink>

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -4,6 +4,7 @@ import {
   ListboxItem,
   Modal,
   ModalContent,
+  Skeleton,
 } from '@heroui/react';
 import { useVisibleRoutes, VisibleRoute } from '@luna/hooks/useVisibleRoutes';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -27,13 +28,15 @@ export function QuickSwitcherModal({
   const visibleRoutes = useVisibleRoutes({});
   const flatRoutes = useMemo(() => flatten(visibleRoutes), [visibleRoutes]);
 
+  const maxResults = 8;
+
   const filteredRoutes = useMemo(() => {
     if (!query) return [];
     const lowerQuery = query.toLowerCase();
     return flatRoutes
       .filter(route => route.name.toLowerCase().includes(lowerQuery))
       .map(route => ({ ...route, key: JSON.stringify(route.path) }))
-      .slice(0, 8);
+      .slice(0, maxResults);
   }, [flatRoutes, query]);
 
   const selectedKey =
@@ -44,7 +47,7 @@ export function QuickSwitcherModal({
   }, [setOpen]);
 
   useEffect(() => {
-    if (isOpen) {
+    if (!isOpen) {
       setQuery('');
     }
   }, [isOpen]);
@@ -68,18 +71,26 @@ export function QuickSwitcherModal({
             />
             {filteredRoutes.length > 0 ? (
               <div className="flex flex-col gap-2 p-2" aria-label="Results">
-                {filteredRoutes.map(route => (
-                  <NavLink to={route.path} key={route.key} onClick={close}>
-                    <div className="flex flex-row gap-2">
-                      {route.icon}
+                {filteredRoutes.map(route =>
+                  route ? (
+                    <NavLink to={route.path} key={route.key} onClick={close}>
                       <div
-                        className={route.key === selectedKey ? 'font-bold' : ''}
+                        className={`flex flex-row gap-2 p-2 rounded-md ${route.key === selectedKey ? 'bg-primary' : ''}`}
                       >
-                        {route.name}
+                        {route.icon}
+                        <div
+                          className={
+                            route.key === selectedKey ? 'font-bold' : ''
+                          }
+                        >
+                          {route.name}
+                        </div>
                       </div>
-                    </div>
-                  </NavLink>
-                ))}
+                    </NavLink>
+                  ) : (
+                    <Skeleton className="h-12" />
+                  )
+                )}
               </div>
             ) : null}
           </div>

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -6,16 +6,22 @@ import { IconMenu2 } from '@tabler/icons-react';
 import React, {
   ReactNode,
   useCallback,
+  useEffect,
   useLayoutEffect,
   useState,
 } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
+import { QuickSwitcherModal } from '@luna/modals/QuickSwitcherModal';
 
 export function HomeScreen() {
   const location = useLocation();
   const breakpoint = useBreakpoint();
+
   const isCompact = breakpoint <= Breakpoint.Sm;
+
   const [isExpanded, setExpanded] = useState(false);
+  const [isQuickSwitcherOpen, setQuickSwitcherOpen] = useState(false);
+
   const [title, setTitle] = useState('');
   const [toolbar, setToolbar] = useState<ReactNode>();
 
@@ -24,6 +30,19 @@ export function HomeScreen() {
   useLayoutEffect(() => {
     setExpanded(false);
   }, [location]);
+
+  useEffect(() => {
+    const listener = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.code === 'KeyK') {
+        setQuickSwitcherOpen(isOpen => !isOpen);
+        e.preventDefault();
+      }
+    };
+    document.addEventListener('keydown', listener);
+    return () => {
+      document.removeEventListener('keydown', listener);
+    };
+  }, []);
 
   const toggleExpanded = useCallback(() => setExpanded(e => !e), []);
 
@@ -55,6 +74,10 @@ export function HomeScreen() {
           <Outlet context={outletContext} />
         </div>
       </div>
+      <QuickSwitcherModal
+        isOpen={isQuickSwitcherOpen}
+        setOpen={setQuickSwitcherOpen}
+      />
     </div>
   );
 }

--- a/src/screens/home/sidebar/Sidebar.tsx
+++ b/src/screens/home/sidebar/Sidebar.tsx
@@ -2,7 +2,6 @@ import { ColorSchemeButton } from '@luna/components/ColorSchemeButton';
 import { SearchBar } from '@luna/components/SearchBar';
 import { UserSnippet } from '@luna/components/UserSnippet';
 import { AuthContext } from '@luna/contexts/api/auth/AuthContext';
-import { ModelContext } from '@luna/contexts/api/model/ModelContext';
 import { SearchContext } from '@luna/contexts/filter/SearchContext';
 import { SidebarRoutes } from '@luna/screens/home/sidebar/SidebarRoutes';
 import {
@@ -25,7 +24,6 @@ export interface SidebarProps {
 
 export function Sidebar({ isCompact }: SidebarProps) {
   const auth = useContext(AuthContext);
-  const model = useContext(ModelContext);
   const { query, setQuery } = useContext(SearchContext);
   const navigate = useNavigate();
 
@@ -51,12 +49,7 @@ export function Sidebar({ isCompact }: SidebarProps) {
         setQuery={setQuery}
       />
       <ScrollShadow className="grow">
-        <SidebarRoutes
-          isCompact={isCompact}
-          searchQuery={query}
-          user={auth.user ?? undefined}
-          allUsernames={[...model.users.all]}
-        />
+        <SidebarRoutes isCompact={isCompact} searchQuery={query} />
       </ScrollShadow>
       <Divider />
       {auth.user ? <UserSnippet user={auth.user} token={auth.token} /> : null}

--- a/src/screens/home/sidebar/Sidebar.tsx
+++ b/src/screens/home/sidebar/Sidebar.tsx
@@ -13,7 +13,7 @@ import {
   ModalHeader,
   ScrollShadow,
 } from '@heroui/react';
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 export interface SidebarProps {
@@ -27,6 +27,8 @@ export function Sidebar({ isCompact }: SidebarProps) {
   const auth = useContext(AuthContext);
   const { query, setQuery } = useContext(SearchContext);
   const navigate = useNavigate();
+
+  const [showQuickSwitcherTip, setShowQuickSwitcherTip] = useState(true);
 
   const [logoutErrorMessage, setLogoutErrorMessage] = useState<string | null>(
     null
@@ -42,6 +44,12 @@ export function Sidebar({ isCompact }: SidebarProps) {
     navigate('/');
   }, [auth, navigate]);
 
+  useEffect(() => {
+    if (query || isCompact) {
+      setShowQuickSwitcherTip(false);
+    }
+  }, [isCompact, query]);
+
   return (
     <div className="flex flex-col space-y-2 h-full">
       <SearchBar
@@ -49,14 +57,16 @@ export function Sidebar({ isCompact }: SidebarProps) {
         fullWidth
         setQuery={setQuery}
         tooltip={
-          <div className="flex flex-col gap-2">
-            <span>
-              Tip: You can also search quickly using the quick switcher.
-            </span>
-            <span>
-              Press <Kbd>Cmd/Ctrl</Kbd> + <Kbd>K</Kbd> to open it.
-            </span>
-          </div>
+          showQuickSwitcherTip ? (
+            <div className="flex flex-col gap-2">
+              <span>
+                Tip: You can also search quickly using the quick switcher.
+              </span>
+              <span>
+                Press <Kbd>Cmd/Ctrl</Kbd> + <Kbd>K</Kbd> to open it.
+              </span>
+            </div>
+          ) : undefined
         }
         tooltipPlacement="right"
       />

--- a/src/screens/home/sidebar/Sidebar.tsx
+++ b/src/screens/home/sidebar/Sidebar.tsx
@@ -6,6 +6,7 @@ import { SearchContext } from '@luna/contexts/filter/SearchContext';
 import { SidebarRoutes } from '@luna/screens/home/sidebar/SidebarRoutes';
 import {
   Divider,
+  Kbd,
   Modal,
   ModalBody,
   ModalContent,
@@ -47,6 +48,17 @@ export function Sidebar({ isCompact }: SidebarProps) {
         placeholder="Search displays..."
         fullWidth
         setQuery={setQuery}
+        tooltip={
+          <div className="flex flex-col gap-2">
+            <span>
+              Tip: You can also search quickly using the quick switcher.
+            </span>
+            <span>
+              Press <Kbd>Cmd/Ctrl</Kbd> + <Kbd>K</Kbd> to open it.
+            </span>
+          </div>
+        }
+        tooltipPlacement="right"
       />
       <ScrollShadow className="grow">
         <SidebarRoutes isCompact={isCompact} searchQuery={query} />

--- a/src/screens/home/sidebar/SidebarRoutes.tsx
+++ b/src/screens/home/sidebar/SidebarRoutes.tsx
@@ -1,104 +1,43 @@
-import { User } from '@luna/contexts/api/auth/types';
 import { RouteLink } from '@luna/components/RouteLink';
+import { useVisibleRoutes, VisibleRoute } from '@luna/hooks/useVisibleRoutes';
 import { truncate } from '@luna/utils/string';
-import {
-  IconBuildingLighthouse,
-  IconCategory,
-  IconFolder,
-  IconHeartRateMonitor,
-  IconKey,
-  IconSettings,
-  IconTower,
-  IconUsers,
-} from '@tabler/icons-react';
-import { memo } from 'react';
 import { InView } from 'react-intersection-observer';
 
 export interface SidebarRoutesProps {
   isCompact: boolean;
   searchQuery: string;
-  user?: User;
-  allUsernames: string[];
 }
 
-// TODO: Migrate to useVisibleRoutes
+export function SidebarRoutes({ isCompact, searchQuery }: SidebarRoutesProps) {
+  const visibleRoutes = useVisibleRoutes({
+    showUserDisplays: !isCompact,
+    searchQuery,
+  });
 
-export const SidebarRoutes = memo(
-  ({ isCompact, searchQuery, user, allUsernames }: SidebarRoutesProps) => {
-    return (
-      <>
-        {user?.roles.find(role => role.name === 'admin') !== undefined ? (
-          <RouteLink icon={<IconTower />} name="Admin" path="/admin">
-            <RouteLink
-              icon={<IconFolder />}
-              name="Resources"
-              path="/admin/resources"
-            />
-            <RouteLink
-              icon={<IconHeartRateMonitor />}
-              name="Monitoring"
-              path="/admin/monitoring"
-            />
-            <RouteLink icon={<IconUsers />} name="Users" path="/admin/users" />
-            <RouteLink
-              icon={<IconCategory />}
-              name="Roles"
-              path="/admin/roles"
-            />
-            <RouteLink
-              icon={<IconKey />}
-              name="Registration Keys"
-              path="/admin/registration-keys"
-            />
-            <RouteLink
-              icon={<IconSettings />}
-              name="Settings"
-              path="/admin/settings"
-            />
-          </RouteLink>
-        ) : (
-          <></>
-        )}
-        <RouteLink
-          icon={<IconBuildingLighthouse />}
-          name="Displays"
-          path="/displays"
-        >
-          {user ? (
-            <RouteLink
-              icon={<IconBuildingLighthouse />}
-              name={`${user.username} (me)`}
-              path={`/displays/${user.username}`}
-            />
-          ) : null}
-          {!isCompact || searchQuery
-            ? allUsernames
-                .filter(
-                  username =>
-                    username !== user?.username &&
-                    username.toLowerCase().includes(searchQuery.toLowerCase())
-                )
-                .sort()
-                .map(username => (
-                  <InView key={username}>
-                    {({ inView, ref }) => (
-                      <div ref={ref}>
-                        <RouteLink
-                          icon={<IconBuildingLighthouse />}
-                          name={truncate(username, 14)}
-                          path={`/displays/${username}`}
-                          isSkeleton={!inView}
-                        />
-                      </div>
-                    )}
-                  </InView>
-                ))
-            : null}
-        </RouteLink>
-      </>
-    );
-  },
-  // Believe it or not, this actually works pretty well and makes things more performant
-  (prevProps, newProps) =>
-    JSON.stringify(prevProps) === JSON.stringify(newProps)
-);
+  return <SidebarVisibleRoutes routes={visibleRoutes} />;
+}
+
+function SidebarVisibleRoutes({ routes }: { routes: VisibleRoute[] }) {
+  return (
+    <>
+      {routes.map(route => (
+        <InView key={route.name}>
+          {({ inView, ref }) => (
+            <div ref={ref}>
+              <RouteLink
+                icon={route.icon}
+                name={truncate(route.name, 14)}
+                path={route.path}
+                isSkeleton={!inView}
+              >
+                {route.children.length > 0 ? (
+                  <SidebarVisibleRoutes routes={route.children} />
+                ) : null}
+              </RouteLink>
+            </div>
+          )}
+        </InView>
+      ))}
+    </>
+  );
+}

--- a/src/screens/home/sidebar/SidebarRoutes.tsx
+++ b/src/screens/home/sidebar/SidebarRoutes.tsx
@@ -26,7 +26,7 @@ function SidebarVisibleRoutes({ routes }: { routes: VisibleRoute[] }) {
             <div ref={ref}>
               <RouteLink
                 icon={route.icon}
-                name={truncate(route.name, 14)}
+                name={truncate(route.name, 18)}
                 path={route.path}
                 isSkeleton={!inView}
               >

--- a/src/screens/home/sidebar/SidebarRoutes.tsx
+++ b/src/screens/home/sidebar/SidebarRoutes.tsx
@@ -21,6 +21,8 @@ export interface SidebarRoutesProps {
   allUsernames: string[];
 }
 
+// TODO: Migrate to useVisibleRoutes
+
 export const SidebarRoutes = memo(
   ({ isCompact, searchQuery, user, allUsernames }: SidebarRoutesProps) => {
     return (


### PR DESCRIPTION
This adds a quick switcher to LUNA, triggered by the conventional <kbd>Cmd/Ctrl</kbd> + <kbd>K</kbd> shortcut, known from Discord, Spotify and other apps, making it quick and easy to navigate the site using the keyboard:

https://github.com/user-attachments/assets/55b96755-7dbd-4d83-acce-3ee82f83e569

(maybe we should document this shortcut somewhere)