### PR TITLE
Add pinned live user and show pinned users in display grid

### DIFF
--- a/src/components/DisplayCard.tsx
+++ b/src/components/DisplayCard.tsx
@@ -2,16 +2,25 @@ import { DISPLAY_ASPECT_RATIO } from '@luna/components/Display';
 import { Card, CardFooter } from '@heroui/react';
 import React, { memo } from 'react';
 import { DisplayStream } from '@luna/screens/home/displays/DisplayStream';
+import { DisplayPin } from '@luna/hooks/usePinnedDisplays';
+import { DisplayPinLabel } from '@luna/components/DisplayPinLabel';
 
 interface DisplayCardProps {
   username: string;
   displayWidth: number;
   className?: string;
+  pin?: DisplayPin;
   isSkeleton?: boolean;
 }
 
 export const DisplayCard = memo(
-  ({ username, displayWidth, className, isSkeleton }: DisplayCardProps) => {
+  ({
+    username,
+    displayWidth,
+    className,
+    pin,
+    isSkeleton,
+  }: DisplayCardProps) => {
     const displayHeight = displayWidth / DISPLAY_ASPECT_RATIO;
 
     return (
@@ -21,15 +30,16 @@ export const DisplayCard = memo(
         ) : (
           <DisplayStream username={username} width={displayWidth} />
         )}
-        <CardFooter className="truncate" style={{ width: displayWidth }}>
+        <CardFooter
+          className="flex flex-row gap-2 truncate"
+          style={{ width: displayWidth }}
+        >
           {username}
+          {pin && !isSkeleton ? <DisplayPinLabel pin={pin} /> : undefined}
         </CardFooter>
       </Card>
     );
   },
   (prevProps, newProps) =>
-    prevProps.isSkeleton === newProps.isSkeleton &&
-    prevProps.className === newProps.className &&
-    prevProps.displayWidth === newProps.displayWidth &&
-    prevProps.username === newProps.username
+    JSON.stringify(prevProps) === JSON.stringify(newProps)
 );

--- a/src/components/DisplayPinLabel.tsx
+++ b/src/components/DisplayPinLabel.tsx
@@ -2,10 +2,10 @@ import { DisplayRouteLabel } from '@luna/components/DisplayRouteLabel';
 import { DisplayPin } from '@luna/hooks/usePinnedDisplays';
 
 export function DisplayPinLabel({
-  isActive,
+  isActive = false,
   pin,
 }: {
-  isActive: boolean;
+  isActive?: boolean;
   pin: DisplayPin;
 }) {
   return (

--- a/src/components/DisplayPinLabel.tsx
+++ b/src/components/DisplayPinLabel.tsx
@@ -1,0 +1,25 @@
+import { DisplayRouteLabel } from '@luna/components/DisplayRouteLabel';
+import { DisplayPin } from '@luna/hooks/usePinnedDisplays';
+
+export function DisplayPinLabel({
+  isActive,
+  pin,
+}: {
+  isActive: boolean;
+  pin: DisplayPin;
+}) {
+  return (
+    <div className="flex flex-row gap-2">
+      {pin.me ? (
+        <DisplayRouteLabel isActive={isActive} color="secondary">
+          me
+        </DisplayRouteLabel>
+      ) : undefined}
+      {pin.live ? (
+        <DisplayRouteLabel isActive={isActive} color="danger">
+          live
+        </DisplayRouteLabel>
+      ) : undefined}
+    </div>
+  );
+}

--- a/src/components/DisplayRouteLabel.tsx
+++ b/src/components/DisplayRouteLabel.tsx
@@ -1,0 +1,62 @@
+import { Chip } from '@heroui/react';
+import {
+  ColorScheme,
+  ColorSchemeContext,
+} from '@luna/contexts/env/ColorSchemeContext';
+import { ReactNode, useContext } from 'react';
+
+type LabelColor = 'default' | 'primary' | 'secondary' | 'danger';
+
+export interface DisplayRouteLabelProps {
+  isActive: boolean;
+  color?: LabelColor;
+  children: ReactNode;
+}
+
+function borderStyle(color: LabelColor, colorScheme: ColorScheme): string {
+  switch (color) {
+    case 'default':
+      return colorScheme.isDark ? 'border-white' : 'border-black';
+    case 'primary':
+      return 'border-primary';
+    case 'secondary':
+      return 'border-secondary';
+    case 'danger':
+      return 'border-danger';
+  }
+}
+
+function textStyle(color: LabelColor, colorScheme: ColorScheme): string {
+  switch (color) {
+    case 'default':
+      return colorScheme.isDark ? 'text-white' : 'text-black';
+    case 'primary':
+      return 'text-primary';
+    case 'secondary':
+      return 'text-secondary';
+    case 'danger':
+      return 'text-danger';
+  }
+}
+export function DisplayRouteLabel({
+  isActive,
+  color = 'default',
+  children,
+}: DisplayRouteLabelProps) {
+  const { colorScheme } = useContext(ColorSchemeContext);
+
+  return (
+    <Chip
+      classNames={{
+        base: isActive ? 'border-white' : borderStyle(color, colorScheme),
+        content: `uppercase font-bold ${
+          isActive ? 'text-white' : textStyle(color, colorScheme)
+        }`,
+      }}
+      variant="bordered"
+      size="sm"
+    >
+      {children}
+    </Chip>
+  );
+}

--- a/src/components/RouteLink.tsx
+++ b/src/components/RouteLink.tsx
@@ -15,7 +15,7 @@ interface RouteLinkParams {
   icon: ReactNode;
   name: string;
   path: string;
-  label?: ReactNode;
+  label?: (params: { isActive: boolean }) => ReactNode;
   isSkeleton?: boolean;
   children?: ReactNode;
 }
@@ -55,7 +55,7 @@ export function RouteLink({
               {icon}
               {name}
             </div>
-            {label ??
+            {label?.({ isActive }) ??
               (children ? (
                 // Intentionally not using a button for the chevron to avoid
                 // https://github.com/ProjectLighthouseCAU/luna/issues/45

--- a/src/components/RouteLink.tsx
+++ b/src/components/RouteLink.tsx
@@ -15,6 +15,7 @@ interface RouteLinkParams {
   icon: ReactNode;
   name: string;
   path: string;
+  label?: ReactNode;
   isSkeleton?: boolean;
   children?: ReactNode;
 }
@@ -23,6 +24,7 @@ export function RouteLink({
   icon,
   name,
   path,
+  label,
   isSkeleton = false,
   children,
 }: RouteLinkParams) {
@@ -53,16 +55,17 @@ export function RouteLink({
               {icon}
               {name}
             </div>
-            {children ? (
-              // Intentionally not using a button for the chevron to avoid
-              // https://github.com/ProjectLighthouseCAU/luna/issues/45
-              <div
-                className={`p-0.5 rounded-md ${isActive || colorScheme.isDark ? 'hover:bg-[rgba(255,255,255,0.2)]' : 'hover:bg-[rgba(128,128,128,0.2)]'} active:opacity-80`}
-                onClick={onPressChevron}
-              >
-                {isExpanded ? <IconChevronDown /> : <IconChevronRight />}
-              </div>
-            ) : null}
+            {label ??
+              (children ? (
+                // Intentionally not using a button for the chevron to avoid
+                // https://github.com/ProjectLighthouseCAU/luna/issues/45
+                <div
+                  className={`p-0.5 rounded-md ${isActive || colorScheme.isDark ? 'hover:bg-[rgba(255,255,255,0.2)]' : 'hover:bg-[rgba(128,128,128,0.2)]'} active:opacity-80`}
+                  onClick={onPressChevron}
+                >
+                  {isExpanded ? <IconChevronDown /> : <IconChevronRight />}
+                </div>
+              ) : null)}
           </>
         )}
       </NavLink>

--- a/src/contexts/env/ColorSchemeContext.tsx
+++ b/src/contexts/env/ColorSchemeContext.tsx
@@ -10,7 +10,7 @@ import {
   useState,
 } from 'react';
 
-interface ColorScheme {
+export interface ColorScheme {
   readonly isDark: boolean;
 }
 

--- a/src/hooks/useLiveUser.ts
+++ b/src/hooks/useLiveUser.ts
@@ -1,0 +1,19 @@
+import { useStream } from '@luna/hooks/useStream';
+import { useMemo } from 'react';
+
+export function useLiveUser() {
+  const livePath = useStream<string[]>(['live']);
+
+  const liveUsername = useMemo(
+    () =>
+      livePath &&
+      livePath.length === 3 &&
+      livePath[0] === 'user' &&
+      livePath[2] === 'model'
+        ? livePath[1]
+        : undefined,
+    [livePath]
+  );
+
+  return { liveUsername };
+}

--- a/src/hooks/useLiveUser.ts
+++ b/src/hooks/useLiveUser.ts
@@ -1,18 +1,21 @@
+import { ModelContext } from '@luna/contexts/api/model/ModelContext';
 import { useStream } from '@luna/hooks/useStream';
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 
 export function useLiveUser() {
   const livePath = useStream<string[]>(['live']);
+  const { users } = useContext(ModelContext);
 
   const liveUsername = useMemo(
     () =>
       livePath &&
       livePath.length === 3 &&
       livePath[0] === 'user' &&
-      livePath[2] === 'model'
+      livePath[2] === 'model' &&
+      users.all.contains(livePath[1])
         ? livePath[1]
         : undefined,
-    [livePath]
+    [livePath, users.all]
   );
 
   return { liveUsername };

--- a/src/hooks/usePinnedDisplays.ts
+++ b/src/hooks/usePinnedDisplays.ts
@@ -1,0 +1,29 @@
+import { AuthContext } from '@luna/contexts/api/auth/AuthContext';
+import { useLiveUser } from '@luna/hooks/useLiveUser';
+import { Map } from 'immutable';
+import { useContext, useMemo } from 'react';
+
+export type DisplayPins = Map<string, DisplayPin>;
+
+export interface DisplayPin {
+  me?: boolean;
+  live?: boolean;
+}
+
+export function usePinnedDisplays(): DisplayPins {
+  const auth = useContext(AuthContext);
+  const { liveUsername } = useLiveUser();
+
+  const pins = useMemo(() => {
+    let pins: DisplayPins = Map();
+    if (auth.user) {
+      pins = pins.update(auth.user.username, {}, pin => ({ ...pin, me: true }));
+    }
+    if (liveUsername) {
+      pins = pins.update(liveUsername, {}, pin => ({ ...pin, live: true }));
+    }
+    return pins;
+  }, [auth.user, liveUsername]);
+
+  return pins;
+}

--- a/src/hooks/usePinnedDisplays.ts
+++ b/src/hooks/usePinnedDisplays.ts
@@ -1,9 +1,9 @@
 import { AuthContext } from '@luna/contexts/api/auth/AuthContext';
 import { useLiveUser } from '@luna/hooks/useLiveUser';
-import { Map } from 'immutable';
+import { OrderedMap } from 'immutable';
 import { useContext, useMemo } from 'react';
 
-export type DisplayPins = Map<string, DisplayPin>;
+export type DisplayPins = OrderedMap<string, DisplayPin>;
 
 export interface DisplayPin {
   me?: boolean;
@@ -15,7 +15,7 @@ export function usePinnedDisplays(): DisplayPins {
   const { liveUsername } = useLiveUser();
 
   const pins = useMemo(() => {
-    let pins: DisplayPins = Map();
+    let pins: DisplayPins = OrderedMap();
     if (auth.user) {
       pins = pins.update(auth.user.username, {}, pin => ({ ...pin, me: true }));
     }

--- a/src/hooks/useVisibleRoutes.tsx
+++ b/src/hooks/useVisibleRoutes.tsx
@@ -20,14 +20,22 @@ interface LabelParams {
   isActive: boolean;
 }
 
-export interface VisibleRoute {
+interface BaseVisibleItem<Type extends string> {
+  type: Type;
   name: string;
+}
+
+export interface VisibleRoute extends BaseVisibleItem<'route'> {
   path: string;
   icon: ReactNode;
   label?: (params: LabelParams) => ReactNode;
   isLazyLoaded?: boolean;
-  children?: VisibleRoute[];
+  children?: VisibleRouteItem[];
 }
+
+export interface VisibleDivider extends BaseVisibleItem<'divider'> {}
+
+export type VisibleRouteItem = VisibleRoute | VisibleDivider;
 
 export function useVisibleRoutes({
   showUserDisplays = true,
@@ -45,39 +53,46 @@ export function useVisibleRoutes({
     [user?.roles]
   );
 
-  const adminRoutes = useMemo(
+  const adminRouteItems = useMemo<VisibleRouteItem[]>(
     () => [
       {
+        type: 'route',
         name: 'Admin',
         path: '/admin',
         icon: <IconTower />,
         children: [
           {
+            type: 'route',
             name: 'Resources',
             path: '/admin/resources',
             icon: <IconFolder />,
           },
           {
+            type: 'route',
             name: 'Monitoring',
             path: '/admin/monitoring',
             icon: <IconHeartRateMonitor />,
           },
           {
+            type: 'route',
             name: 'Users',
             path: '/admin/users',
             icon: <IconUsers />,
           },
           {
+            type: 'route',
             name: 'Roles',
             path: '/admin/roles',
             icon: <IconCategory />,
           },
           {
+            type: 'route',
             name: 'Registration Keys',
             path: '/admin/registration-keys',
             icon: <IconKey />,
           },
           {
+            type: 'route',
             name: 'Settings',
             path: '/admin/settings',
             icon: <IconSettings />,
@@ -127,44 +142,62 @@ export function useVisibleRoutes({
     [pinnedUsers]
   );
 
-  const userRoutes = useMemo(
+  const remainingUsernames = useMemo(
+    () =>
+      allUsernames
+        .filter(
+          username =>
+            !pinnedUsernames.contains(username) &&
+            username.toLowerCase().includes(searchQuery.toLowerCase())
+        )
+        .sort(),
+    [allUsernames, pinnedUsernames, searchQuery]
+  );
+
+  const userRouteItems = useMemo<VisibleRouteItem[]>(
     () => [
       {
+        type: 'route',
         name: 'Displays',
         path: '/displays',
         icon: <IconBuildingLighthouse />,
         children: [
           ...pinnedUsers.map(pinned => ({
+            type: 'route' as const,
             name: pinned.username,
             icon: <IconBuildingLighthouse />,
             label: pinned.label,
             path: `/displays/${pinned.username}`,
           })),
           ...(showUserDisplays || searchQuery
-            ? allUsernames
-                .filter(
-                  username =>
-                    !pinnedUsernames.contains(username) &&
-                    username.toLowerCase().includes(searchQuery.toLowerCase())
-                )
-                .sort()
-                .map<VisibleRoute>(username => ({
+            ? [
+                ...(pinnedUsers.length > 0 && remainingUsernames.length > 0
+                  ? [
+                      {
+                        type: 'divider' as const,
+                        name: 'Pinned Users Divider',
+                      },
+                    ]
+                  : []),
+                ...remainingUsernames.map<VisibleRouteItem>(username => ({
+                  type: 'route',
                   name: username,
                   path: `/displays/${username}`,
                   icon: <IconBuildingLighthouse />,
                   isLazyLoaded: true,
-                }))
+                })),
+              ]
             : []),
         ],
       },
     ],
-    [allUsernames, pinnedUsernames, pinnedUsers, searchQuery, showUserDisplays]
+    [pinnedUsers, remainingUsernames, searchQuery, showUserDisplays]
   );
 
-  const routes = useMemo<VisibleRoute[]>(
-    () => [...(isAdmin ? adminRoutes : []), ...userRoutes],
-    [adminRoutes, isAdmin, userRoutes]
+  const routeItems = useMemo<VisibleRouteItem[]>(
+    () => [...(isAdmin ? adminRouteItems : []), ...userRouteItems],
+    [adminRouteItems, isAdmin, userRouteItems]
   );
 
-  return routes;
+  return routeItems;
 }

--- a/src/hooks/useVisibleRoutes.tsx
+++ b/src/hooks/useVisibleRoutes.tsx
@@ -13,12 +13,17 @@ import {
 } from '@tabler/icons-react';
 import { ReactNode, useContext, useMemo } from 'react';
 import { Set } from 'immutable';
+import { Chip } from '@heroui/react';
+
+interface LabelParams {
+  isActive: boolean;
+}
 
 export interface VisibleRoute {
   name: string;
   path: string;
   icon: ReactNode;
-  label?: ReactNode;
+  label?: (params: LabelParams) => ReactNode;
   isLazyLoaded?: boolean;
   children?: VisibleRoute[];
 }
@@ -90,7 +95,20 @@ export function useVisibleRoutes({
         ? [
             {
               username: user.username,
-              label: 'me',
+              label: ({ isActive }: LabelParams) => (
+                <Chip
+                  classNames={{
+                    base: isActive ? 'border-white' : 'border-secondary',
+                    content: `uppercase font-bold ${
+                      isActive ? 'text-white' : 'text-secondary'
+                    }`,
+                  }}
+                  variant="bordered"
+                  size="sm"
+                >
+                  me
+                </Chip>
+              ),
             },
           ]
         : []),

--- a/src/hooks/useVisibleRoutes.tsx
+++ b/src/hooks/useVisibleRoutes.tsx
@@ -13,7 +13,7 @@ import {
 } from '@tabler/icons-react';
 import { ReactNode, useContext, useMemo } from 'react';
 import { Set } from 'immutable';
-import { Chip } from '@heroui/react';
+import { DisplayRouteLabel } from '@luna/components/DisplayRouteLabel';
 
 interface LabelParams {
   isActive: boolean;
@@ -96,18 +96,9 @@ export function useVisibleRoutes({
             {
               username: user.username,
               label: ({ isActive }: LabelParams) => (
-                <Chip
-                  classNames={{
-                    base: isActive ? 'border-white' : 'border-secondary',
-                    content: `uppercase font-bold ${
-                      isActive ? 'text-white' : 'text-secondary'
-                    }`,
-                  }}
-                  variant="bordered"
-                  size="sm"
-                >
+                <DisplayRouteLabel isActive={isActive} color="secondary">
                   me
-                </Chip>
+                </DisplayRouteLabel>
               ),
             },
           ]

--- a/src/hooks/useVisibleRoutes.tsx
+++ b/src/hooks/useVisibleRoutes.tsx
@@ -1,8 +1,8 @@
-import { DisplayRouteLabel } from '@luna/components/DisplayRouteLabel';
+import { DisplayPinLabel } from '@luna/components/DisplayPinLabel';
 import { AuthContext } from '@luna/contexts/api/auth/AuthContext';
 import { ModelContext } from '@luna/contexts/api/model/ModelContext';
 import { useJsonMemo } from '@luna/hooks/useJsonMemo';
-import { DisplayPin, usePinnedDisplays } from '@luna/hooks/usePinnedDisplays';
+import { usePinnedDisplays } from '@luna/hooks/usePinnedDisplays';
 import {
   IconBuildingLighthouse,
   IconCategory,
@@ -166,27 +166,4 @@ export function useVisibleRoutes({
   );
 
   return routeItems;
-}
-
-function DisplayPinLabel({
-  isActive,
-  pin,
-}: {
-  isActive: boolean;
-  pin: DisplayPin;
-}) {
-  return (
-    <div className="flex flex-row gap-2">
-      {pin.me ? (
-        <DisplayRouteLabel isActive={isActive} color="secondary">
-          me
-        </DisplayRouteLabel>
-      ) : undefined}
-      {pin.live ? (
-        <DisplayRouteLabel isActive={isActive} color="danger">
-          live
-        </DisplayRouteLabel>
-      ) : undefined}
-    </div>
-  );
 }

--- a/src/hooks/useVisibleRoutes.tsx
+++ b/src/hooks/useVisibleRoutes.tsx
@@ -14,6 +14,7 @@ import {
 import { ReactNode, useContext, useMemo } from 'react';
 import { Set } from 'immutable';
 import { DisplayRouteLabel } from '@luna/components/DisplayRouteLabel';
+import { useLiveUser } from '@luna/hooks/useLiveUser';
 
 interface LabelParams {
   isActive: boolean;
@@ -89,6 +90,8 @@ export function useVisibleRoutes({
 
   const allUsernames = useJsonMemo([...users.all]);
 
+  const { liveUsername } = useLiveUser();
+
   const pinnedUsers = useMemo(
     () => [
       ...(user?.username
@@ -103,8 +106,20 @@ export function useVisibleRoutes({
             },
           ]
         : []),
+      ...(liveUsername
+        ? [
+            {
+              username: liveUsername,
+              label: ({ isActive }: LabelParams) => (
+                <DisplayRouteLabel isActive={isActive} color="danger">
+                  live
+                </DisplayRouteLabel>
+              ),
+            },
+          ]
+        : []),
     ],
-    [user?.username]
+    [liveUsername, user?.username]
   );
 
   const pinnedUsernames = useMemo(

--- a/src/hooks/useVisibleRoutes.tsx
+++ b/src/hooks/useVisibleRoutes.tsx
@@ -18,6 +18,7 @@ export interface VisibleRoute {
   name: string;
   path: string;
   icon: ReactNode;
+  label?: ReactNode;
   isLazyLoaded?: boolean;
   children?: VisibleRoute[];
 }
@@ -110,8 +111,9 @@ export function useVisibleRoutes({
         icon: <IconBuildingLighthouse />,
         children: [
           ...pinnedUsers.map(pinned => ({
-            name: `${pinned.username} (${pinned.label})`,
+            name: pinned.username,
             icon: <IconBuildingLighthouse />,
+            label: pinned.label,
             path: `/displays/${pinned.username}`,
           })),
           ...(showUserDisplays || searchQuery

--- a/src/hooks/useVisibleRoutes.tsx
+++ b/src/hooks/useVisibleRoutes.tsx
@@ -18,8 +18,8 @@ export interface VisibleRoute {
   name: string;
   path: string;
   icon: ReactNode;
-  isLazyLoaded: boolean;
-  children: VisibleRoute[];
+  isLazyLoaded?: boolean;
+  children?: VisibleRoute[];
 }
 
 export function useVisibleRoutes({
@@ -44,49 +44,36 @@ export function useVisibleRoutes({
         name: 'Admin',
         path: '/admin',
         icon: <IconTower />,
-        isLazyLoaded: false,
         children: [
           {
             name: 'Resources',
             path: '/admin/resources',
             icon: <IconFolder />,
-            isLazyLoaded: false,
-            children: [],
           },
           {
             name: 'Monitoring',
             path: '/admin/monitoring',
             icon: <IconHeartRateMonitor />,
-            isLazyLoaded: false,
-            children: [],
           },
           {
             name: 'Users',
             path: '/admin/users',
             icon: <IconUsers />,
-            isLazyLoaded: false,
-            children: [],
           },
           {
             name: 'Roles',
             path: '/admin/roles',
             icon: <IconCategory />,
-            isLazyLoaded: false,
-            children: [],
           },
           {
             name: 'Registration Keys',
             path: '/admin/registration-keys',
             icon: <IconKey />,
-            isLazyLoaded: false,
-            children: [],
           },
           {
             name: 'Settings',
             path: '/admin/settings',
             icon: <IconSettings />,
-            isLazyLoaded: false,
-            children: [],
           },
         ],
       },
@@ -121,14 +108,11 @@ export function useVisibleRoutes({
         name: 'Displays',
         path: '/displays',
         icon: <IconBuildingLighthouse />,
-        isLazyLoaded: false,
         children: [
           ...pinnedUsers.map(pinned => ({
             name: `${pinned.username} (${pinned.label})`,
             icon: <IconBuildingLighthouse />,
             path: `/displays/${pinned.username}`,
-            isLazyLoaded: false,
-            children: [],
           })),
           ...(showUserDisplays || searchQuery
             ? allUsernames
@@ -143,7 +127,6 @@ export function useVisibleRoutes({
                   path: `/displays/${username}`,
                   icon: <IconBuildingLighthouse />,
                   isLazyLoaded: true,
-                  children: [],
                 }))
             : []),
         ],

--- a/src/hooks/useVisibleRoutes.tsx
+++ b/src/hooks/useVisibleRoutes.tsx
@@ -126,18 +126,15 @@ export function useVisibleRoutes({
         path: '/displays',
         icon: <IconBuildingLighthouse />,
         children: [
-          ...pinnedDisplays
-            .entrySeq()
-            .sortBy(([_, pin]) => `${pin.me ? 0 : 1}${pin.live ? 0 : 1}`)
-            .map(([username, pin]) => ({
-              type: 'route' as const,
-              name: username,
-              icon: <IconBuildingLighthouse />,
-              label: ({ isActive }: LabelParams) => (
-                <DisplayPinLabel isActive={isActive} pin={pin} />
-              ),
-              path: `/displays/${username}`,
-            })),
+          ...pinnedDisplays.entrySeq().map(([username, pin]) => ({
+            type: 'route' as const,
+            name: username,
+            icon: <IconBuildingLighthouse />,
+            label: ({ isActive }: LabelParams) => (
+              <DisplayPinLabel isActive={isActive} pin={pin} />
+            ),
+            path: `/displays/${username}`,
+          })),
           ...(showUserDisplays || searchQuery
             ? [
                 ...(pinnedDisplays.size > 0 && remainingUsernames.length > 0

--- a/src/hooks/useVisibleRoutes.tsx
+++ b/src/hooks/useVisibleRoutes.tsx
@@ -104,11 +104,6 @@ export function useVisibleRoutes({
 
   const pinnedDisplays = usePinnedDisplays();
 
-  const pinnedUsernames = useMemo(
-    () => [...pinnedDisplays.keys()].sort(),
-    [pinnedDisplays]
-  );
-
   const allUsernames = useJsonMemo([...users.all]);
 
   const remainingUsernames = useMemo(
@@ -131,18 +126,18 @@ export function useVisibleRoutes({
         path: '/displays',
         icon: <IconBuildingLighthouse />,
         children: [
-          ...pinnedUsernames.map(username => ({
-            type: 'route' as const,
-            name: username,
-            icon: <IconBuildingLighthouse />,
-            label: ({ isActive }: LabelParams) => (
-              <DisplayPinLabel
-                isActive={isActive}
-                pin={pinnedDisplays.get(username) ?? {}}
-              />
-            ),
-            path: `/displays/${username}`,
-          })),
+          ...pinnedDisplays
+            .entrySeq()
+            .sortBy(([_, pin]) => `${pin.me ? 0 : 1}${pin.live ? 0 : 1}`)
+            .map(([username, pin]) => ({
+              type: 'route' as const,
+              name: username,
+              icon: <IconBuildingLighthouse />,
+              label: ({ isActive }: LabelParams) => (
+                <DisplayPinLabel isActive={isActive} pin={pin} />
+              ),
+              path: `/displays/${username}`,
+            })),
           ...(showUserDisplays || searchQuery
             ? [
                 ...(pinnedDisplays.size > 0 && remainingUsernames.length > 0
@@ -165,13 +160,7 @@ export function useVisibleRoutes({
         ],
       },
     ],
-    [
-      pinnedDisplays,
-      pinnedUsernames,
-      remainingUsernames,
-      searchQuery,
-      showUserDisplays,
-    ]
+    [pinnedDisplays, remainingUsernames, searchQuery, showUserDisplays]
   );
 
   const routeItems = useMemo<VisibleRouteItem[]>(

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -121,26 +121,29 @@ export function QuickSwitcherModal({
                   route ? (
                     <NavLink to={route.path} key={route.key} onClick={onClose}>
                       <div
-                        className={`flex flex-row p-2 gap-2 items-center rounded-md ${route.key === selectedRoute?.key ? 'bg-primary text-white' : ''}`}
+                        className={`flex flex-row justify-between p-2 gap-2 items-center rounded-md ${route.key === selectedRoute?.key ? 'bg-primary text-white' : ''}`}
                       >
-                        {route.icon}
-                        <div className="flex flex-row items-center">
-                          {route.parentNames.map(name => (
-                            <div key={name} className="flex flex-row">
-                              {name}
-                              <IconChevronRight />
+                        <div className={`flex flex-row gap-2 items-center`}>
+                          {route.icon}
+                          <div className="flex flex-row items-center">
+                            {route.parentNames.map(name => (
+                              <div key={name} className="flex flex-row">
+                                {name}
+                                <IconChevronRight />
+                              </div>
+                            ))}
+                            <div
+                              className={
+                                route.key === selectedRoute?.key
+                                  ? 'font-bold'
+                                  : ''
+                              }
+                            >
+                              {route.name}
                             </div>
-                          ))}
-                          <div
-                            className={
-                              route.key === selectedRoute?.key
-                                ? 'font-bold'
-                                : ''
-                            }
-                          >
-                            {route.name}
                           </div>
                         </div>
+                        {route.label}
                       </div>
                     </NavLink>
                   ) : (

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -143,7 +143,9 @@ export function QuickSwitcherModal({
                             </div>
                           </div>
                         </div>
-                        {route.label}
+                        {route.label?.({
+                          isActive: route.key === selectedRoute?.key,
+                        })}
                       </div>
                     </NavLink>
                   ) : (

--- a/src/modals/QuickSwitcherModal.tsx
+++ b/src/modals/QuickSwitcherModal.tsx
@@ -23,7 +23,7 @@ function flatten(
     routes
       .flatMap(route => [
         { ...route, parentNames },
-        ...flatten(route.children, [...parentNames, route.name]),
+        ...flatten(route.children ?? [], [...parentNames, route.name]),
       ])
       // Prioritize longer paths
       .sort((a, b) => b.path.length - a.path.length)

--- a/src/screens/home/displays/DisplayGrid.tsx
+++ b/src/screens/home/displays/DisplayGrid.tsx
@@ -6,7 +6,7 @@ import { displayLayoutId } from '@luna/constants/LayoutId';
 import { Users } from '@luna/contexts/api/model/ModelContext';
 import { useMemo } from 'react';
 import { Divider } from '@heroui/react';
-import { usePinnedDisplays } from '@luna/hooks/usePinnedDisplays';
+import { DisplayPin, usePinnedDisplays } from '@luna/hooks/usePinnedDisplays';
 
 export interface DisplayGridProps {
   users: Users;
@@ -40,12 +40,13 @@ export function DisplayGrid({
 
   return (
     <div className="flex flex-wrap gap-4 justify-center">
-      {[...pinnedDisplays.keys()].map(username => (
+      {[...pinnedDisplays.entries()].map(([username, pin]) => (
         <DisplayLink
           key={username}
           username={username}
           animationsEnabled={animationsEnabled}
           displayWidth={displayWidth}
+          pin={pin}
         />
       ))}
       <Divider />
@@ -67,10 +68,12 @@ function DisplayLink({
   username,
   animationsEnabled,
   displayWidth,
+  pin,
 }: {
   username: string;
   animationsEnabled: boolean;
   displayWidth: number;
+  pin?: DisplayPin;
 }) {
   return (
     <Link to={username}>
@@ -85,6 +88,7 @@ function DisplayLink({
             <DisplayCard
               username={username}
               displayWidth={displayWidth}
+              pin={pin}
               isSkeleton={!inView}
             />
           </motion.div>

--- a/src/screens/home/displays/DisplayGrid.tsx
+++ b/src/screens/home/displays/DisplayGrid.tsx
@@ -5,6 +5,8 @@ import { motion } from 'framer-motion';
 import { displayLayoutId } from '@luna/constants/LayoutId';
 import { Users } from '@luna/contexts/api/model/ModelContext';
 import { useMemo } from 'react';
+import { Divider } from '@heroui/react';
+import { usePinnedDisplays } from '@luna/hooks/usePinnedDisplays';
 
 export interface DisplayGridProps {
   users: Users;
@@ -17,13 +19,17 @@ export function DisplayGrid({
   searchQuery,
   displayWidth,
 }: DisplayGridProps) {
+  const pinnedDisplays = usePinnedDisplays();
+
   // Filter the models case-insensitively by the search query
   const filteredUsers = useMemo(
     () =>
-      users.all.filter(username =>
-        username.toLowerCase().includes(searchQuery.toLowerCase())
+      users.all.filter(
+        username =>
+          !pinnedDisplays.has(username) &&
+          username.toLowerCase().includes(searchQuery.toLowerCase())
       ),
-    [searchQuery, users.all]
+    [pinnedDisplays, searchQuery, users.all]
   );
 
   // Disable animations automatically if there are too many displays for
@@ -34,28 +40,56 @@ export function DisplayGrid({
 
   return (
     <div className="flex flex-wrap gap-4 justify-center">
+      {[...pinnedDisplays.keys()].map(username => (
+        <DisplayLink
+          key={username}
+          username={username}
+          animationsEnabled={animationsEnabled}
+          displayWidth={displayWidth}
+        />
+      ))}
+      <Divider />
       {[...filteredUsers]
         .sort((u1, u2) => u1.localeCompare(u2))
         .map(username => (
-          <Link to={username} key={username}>
-            <InView>
-              {({ inView, ref }) => (
-                <motion.div
-                  ref={ref}
-                  {...(animationsEnabled
-                    ? { layoutId: displayLayoutId(username) }
-                    : {})}
-                >
-                  <DisplayCard
-                    username={username}
-                    displayWidth={displayWidth}
-                    isSkeleton={!inView}
-                  />
-                </motion.div>
-              )}
-            </InView>
-          </Link>
+          <DisplayLink
+            key={username}
+            username={username}
+            animationsEnabled={animationsEnabled}
+            displayWidth={displayWidth}
+          />
         ))}
     </div>
+  );
+}
+
+function DisplayLink({
+  username,
+  animationsEnabled,
+  displayWidth,
+}: {
+  username: string;
+  animationsEnabled: boolean;
+  displayWidth: number;
+}) {
+  return (
+    <Link to={username}>
+      <InView>
+        {({ inView, ref }) => (
+          <motion.div
+            ref={ref}
+            {...(animationsEnabled
+              ? { layoutId: displayLayoutId(username) }
+              : {})}
+          >
+            <DisplayCard
+              username={username}
+              displayWidth={displayWidth}
+              isSkeleton={!inView}
+            />
+          </motion.div>
+        )}
+      </InView>
+    </Link>
   );
 }

--- a/src/screens/home/sidebar/SidebarRoutes.tsx
+++ b/src/screens/home/sidebar/SidebarRoutes.tsx
@@ -35,7 +35,7 @@ function SidebarVisibleRoute({ route }: { route: VisibleRoute }) {
       path={route.path}
       isSkeleton={!inView}
     >
-      {route.children.length > 0 ? (
+      {route.children && route.children.length > 0 ? (
         <SidebarVisibleRoutes routes={route.children} />
       ) : null}
     </RouteLink>

--- a/src/screens/home/sidebar/SidebarRoutes.tsx
+++ b/src/screens/home/sidebar/SidebarRoutes.tsx
@@ -1,5 +1,10 @@
+import { Divider } from '@heroui/react';
 import { RouteLink } from '@luna/components/RouteLink';
-import { useVisibleRoutes, VisibleRoute } from '@luna/hooks/useVisibleRoutes';
+import {
+  useVisibleRoutes,
+  VisibleRoute,
+  VisibleRouteItem,
+} from '@luna/hooks/useVisibleRoutes';
 import { truncate } from '@luna/utils/string';
 import { InView } from 'react-intersection-observer';
 
@@ -9,22 +14,42 @@ export interface SidebarRoutesProps {
 }
 
 export function SidebarRoutes({ isCompact, searchQuery }: SidebarRoutesProps) {
-  const visibleRoutes = useVisibleRoutes({
+  const visibleRouteItems = useVisibleRoutes({
     showUserDisplays: !isCompact,
     searchQuery,
   });
 
-  return <SidebarVisibleRoutes routes={visibleRoutes} />;
+  return <SidebarVisibleRouteItems routeItems={visibleRouteItems} />;
 }
 
-function SidebarVisibleRoutes({ routes }: { routes: VisibleRoute[] }) {
+function SidebarVisibleRouteItems({
+  routeItems,
+}: {
+  routeItems: VisibleRouteItem[];
+}) {
   return (
     <>
-      {routes.map(route => (
-        <SidebarVisibleRoute key={route.name} route={route} />
+      {routeItems.map(item => (
+        <SidebarVisibleRouteItem
+          key={`${item.type}$${item.name}`}
+          routeItem={item}
+        />
       ))}
     </>
   );
+}
+
+function SidebarVisibleRouteItem({
+  routeItem,
+}: {
+  routeItem: VisibleRouteItem;
+}) {
+  switch (routeItem.type) {
+    case 'route':
+      return <SidebarVisibleRoute route={routeItem} />;
+    case 'divider':
+      return <Divider />;
+  }
 }
 
 function SidebarVisibleRoute({ route }: { route: VisibleRoute }) {
@@ -37,7 +62,7 @@ function SidebarVisibleRoute({ route }: { route: VisibleRoute }) {
       isSkeleton={!inView}
     >
       {route.children && route.children.length > 0 ? (
-        <SidebarVisibleRoutes routes={route.children} />
+        <SidebarVisibleRouteItems routeItems={route.children} />
       ) : null}
     </RouteLink>
   );

--- a/src/screens/home/sidebar/SidebarRoutes.tsx
+++ b/src/screens/home/sidebar/SidebarRoutes.tsx
@@ -32,6 +32,7 @@ function SidebarVisibleRoute({ route }: { route: VisibleRoute }) {
     <RouteLink
       icon={route.icon}
       name={truncate(route.name, 18)}
+      label={route.label}
       path={route.path}
       isSkeleton={!inView}
     >


### PR DESCRIPTION
This pins the current live user to the top of the display list and includes some refactorings under the hood to make these pinned displays more easily accessible (via a new `usePinnedDisplays` hook):

![image](https://github.com/user-attachments/assets/8ce0f0f4-a393-422f-8bdd-69a1c7cdc6d0)

This implements part 1 of #97.