### PR TITLE
Add `useLaserMetrics` hook

### DIFF
--- a/src/contexts/api/model/ModelContext.tsx
+++ b/src/contexts/api/model/ModelContext.tsx
@@ -1,5 +1,5 @@
 import { AuthContext } from '@luna/contexts/api/auth/AuthContext';
-import { LaserMetrics, UserModel } from '@luna/contexts/api/model/types';
+import { UserModel } from '@luna/contexts/api/model/types';
 import { errorResult, getOrThrow, okResult, Result } from '@luna/utils/result';
 import { Set } from 'immutable';
 import {
@@ -69,9 +69,6 @@ export interface ModelAPI {
 
   /** Moves a resource to an arbitrary path. */
   move(path: string[], newPath: string[]): Promise<Result<void>>;
-
-  /** Fetches lamp server metrics. */
-  getLaserMetrics(): Promise<Result<LaserMetrics>>;
 }
 
 export interface ModelContextValue {
@@ -101,8 +98,6 @@ export const ModelContext = createContext<ModelContextValue>({
     mkdir: async () => errorResult('No model context for creating directory'),
     isDirectory: async () => false,
     move: async () => errorResult('No model context for moving resource'),
-    getLaserMetrics: async () =>
-      errorResult('No model context for fetching laser metrics'),
   },
 });
 
@@ -261,9 +256,6 @@ export function ModelContextProvider({ children }: ModelContextProviderProps) {
         } catch (error) {
           return errorResult(error);
         }
-      },
-      async getLaserMetrics() {
-        return (await this.get(['metrics', 'laser'])) as Result<LaserMetrics>;
       },
     }),
     [client]

--- a/src/hooks/useLaserMetrics.ts
+++ b/src/hooks/useLaserMetrics.ts
@@ -1,0 +1,6 @@
+import { LaserMetrics } from '@luna/contexts/api/model/types';
+import { useStream } from '@luna/hooks/useStream';
+
+export function useLaserMetrics() {
+  return useStream<LaserMetrics>(['metrics', 'laser']);
+}

--- a/src/screens/home/admin/MonitorView.tsx
+++ b/src/screens/home/admin/MonitorView.tsx
@@ -3,21 +3,21 @@ import {
   Display,
   DisplayMouse,
 } from '@luna/components/Display';
-import { LaserMetrics, RoomV2Metrics } from '@luna/contexts/api/model/types';
+import { RoomV2Metrics } from '@luna/contexts/api/model/types';
 import { Breakpoint, useBreakpoint } from '@luna/hooks/useBreakpoint';
 import { useEventListener } from '@luna/hooks/useEventListener';
+import { useLaserMetrics } from '@luna/hooks/useLaserMetrics';
 import { flattenRoomV2Metrics } from '@luna/screens/home/admin/helpers/FlatRoomV2Metrics';
 import { MonitorCriterion } from '@luna/screens/home/admin/helpers/MonitorCriterion';
 import { MonitorInspector } from '@luna/screens/home/admin/MonitorInspector';
 import { HomeContent } from '@luna/screens/home/HomeContent';
+import { Bounded, isBounded } from '@luna/utils/bounded';
 import * as rgb from '@luna/utils/rgb';
 import { throttle } from '@luna/utils/schedule';
 import { Vec2 } from '@luna/utils/vec2';
 import { Set } from 'immutable';
 import { LIGHTHOUSE_COLS, LIGHTHOUSE_FRAME_BYTES } from 'nighthouse/browser';
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { Bounded, isBounded } from '@luna/utils/bounded';
-import { useStream } from '@luna/hooks/useStream';
 
 export function MonitorView() {
   const [maxSize, setMaxSize] = useState({ width: 0, height: 0 });
@@ -47,7 +47,7 @@ export function MonitorView() {
       ? maxSize.width
       : maxSize.height * DISPLAY_ASPECT_RATIO;
 
-  const metrics = useStream<LaserMetrics>(['metrics', 'laser']);
+  const metrics = useLaserMetrics();
 
   const [focusedRoom, setSelectedRoom] = useState<number>();
   const [hoveredRoom, setHoveredRoom] = useState<number>();


### PR DESCRIPTION
Hooks seem to be a better abstraction for this than exposing the specific paths in the model context, so let's do it this way.