### PR TITLE
Add fallback for `crypto.randomUUID`

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,9 @@ import { HeroUIProvider } from '@heroui/react';
 import { RouterProvider } from 'react-router-dom';
 import { ClientIdContextProvider } from '@luna/contexts/env/ClientIdContext';
 import { UserPinsContextProvider } from '@luna/contexts/displays/UserPinsContext';
+import { randomUUID } from '@luna/utils/uuid';
 
-const clientId = crypto.randomUUID();
+const clientId = randomUUID();
 
 export function App() {
   return (

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,15 @@
+/** Generates a random UUIDv4. */
+export function randomUUID(): string {
+  if (typeof crypto === 'object' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  } else {
+    // Fallback, e.g. for non-HTTPS/local contexts, see https://stackoverflow.com/a/2117523
+    console.warn('Using fallback UUID generator');
+    return '10000000-1000-4000-8000-100000000000'.replace(/[018]/g, c =>
+      (
+        +c ^
+        (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (+c / 4)))
+      ).toString(16)
+    );
+  }
+}


### PR DESCRIPTION
This is mostly useful for testing LUNA on the local network where HTTPS isn't available, but might also help if the browser doesn't support this particular API.