### PR TITLE
Activate context menu on long touches

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -15,13 +15,38 @@ export function ContextMenu({ menu, children }: ContextMenuProps) {
     if (div === null) {
       return;
     }
-    const listener = (e: MouseEvent) => {
+    const onContextMenu = (e: MouseEvent) => {
       e.preventDefault();
       setShown(isShown => !isShown);
     };
-    div.addEventListener('contextmenu', listener);
+
+    const longTouchDelayMs = 800;
+    let longTouchTimer: number | null = null;
+
+    const onTouchStart = (e: TouchEvent) => {
+      e.preventDefault();
+      if (e !== null) {
+        longTouchTimer = window.setTimeout(() => {
+          setShown(true);
+        }, longTouchDelayMs);
+      }
+    };
+
+    const onTouchEnd = (e: TouchEvent) => {
+      if (longTouchTimer !== null) {
+        window.clearTimeout(longTouchTimer);
+        longTouchTimer = null;
+      }
+    };
+
+    div.addEventListener('contextmenu', onContextMenu);
+    div.addEventListener('touchstart', onTouchStart);
+    div.addEventListener('touchend', onTouchEnd);
+
     return () => {
-      div.removeEventListener('contextmenu', listener);
+      div.removeEventListener('contextmenu', onContextMenu);
+      div.removeEventListener('touchstart', onTouchStart);
+      div.removeEventListener('touchend', onTouchEnd);
     };
   }, []);
 

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -24,7 +24,6 @@ export function ContextMenu({ menu, children }: ContextMenuProps) {
     let longTouchTimer: number | null = null;
 
     const onTouchStart = (e: TouchEvent) => {
-      e.preventDefault();
       if (e !== null) {
         longTouchTimer = window.setTimeout(() => {
           setShown(true);
@@ -51,7 +50,7 @@ export function ContextMenu({ menu, children }: ContextMenuProps) {
   }, []);
 
   return menu ? (
-    <div ref={divRef}>
+    <div ref={divRef} className="no-webkit-callout">
       {children}
       <Dropdown isOpen={isShown} onOpenChange={setShown}>
         <DropdownTrigger>

--- a/src/index.css
+++ b/src/index.css
@@ -31,3 +31,8 @@ a:active {
   top: 5em;
   z-index: 20;
 }
+
+.no-webkit-callout {
+  /* Disables popover-style context menus on iOS, which we need for our own long-press context menu implementation. */
+  -webkit-touch-callout: none;
+}


### PR DESCRIPTION
### Fixes #113 

This adds a custom context menu implementation that triggers on long touches and doesn't interfere with normal events.