### PR TITLE
Add "Actions" card to display inspector

### DIFF
--- a/src/components/DisplayActionsMenu.tsx
+++ b/src/components/DisplayActionsMenu.tsx
@@ -40,7 +40,7 @@ export function DisplayActionsMenu({
     () => [
       {
         key: 'pin',
-        label: isPinned ? 'Unpin' : 'Pin',
+        label: `${isPinned ? 'Unpin' : 'Pin'} ${username}`,
         onPress: togglePinned,
       },
       ...(isAdmin

--- a/src/components/DisplayActionsMenu.tsx
+++ b/src/components/DisplayActionsMenu.tsx
@@ -1,0 +1,61 @@
+import { UserPinsContext } from '@luna/contexts/displays/UserPinsContext';
+import { useAdminStatus } from '@luna/hooks/useAdminStatus';
+import { useLiveUser } from '@luna/hooks/useLiveUser';
+import { ReactNode, useCallback, useContext, useMemo } from 'react';
+
+export interface DisplayActionMenuItem {
+  key: string;
+  label: string;
+  onPress: () => void;
+  danger?: boolean;
+}
+
+export interface DisplayActionsMenuProps {
+  username: string;
+  children: (params: { items: DisplayActionMenuItem[] }) => ReactNode;
+}
+
+export function DisplayActionsMenu({
+  username,
+  children,
+}: DisplayActionsMenuProps) {
+  const { pinnedUsernames, setPinnedUsernames } = useContext(UserPinsContext);
+  const { isAdmin } = useAdminStatus();
+  const { setLiveUsername } = useLiveUser();
+
+  const isPinned = pinnedUsernames.contains(username);
+  const togglePinned = useCallback(() => {
+    setPinnedUsernames(
+      isPinned
+        ? pinnedUsernames.remove(username)
+        : pinnedUsernames.add(username)
+    );
+  }, [isPinned, pinnedUsernames, setPinnedUsernames, username]);
+
+  const goLive = useCallback(() => {
+    setLiveUsername(username);
+  }, [setLiveUsername, username]);
+
+  const items = useMemo<DisplayActionMenuItem[]>(
+    () => [
+      {
+        key: 'pin',
+        label: isPinned ? 'Unpin' : 'Pin',
+        onPress: togglePinned,
+      },
+      ...(isAdmin
+        ? [
+            {
+              key: 'live',
+              onPress: goLive,
+              label: `Set ${username} to Live`,
+              danger: true,
+            },
+          ]
+        : []),
+    ],
+    [goLive, isAdmin, isPinned, togglePinned, username]
+  );
+
+  return <>{children({ items })}</>;
+}

--- a/src/components/DisplayContextMenu.tsx
+++ b/src/components/DisplayContextMenu.tsx
@@ -1,46 +1,27 @@
 import { DropdownItem, DropdownMenu } from '@heroui/react';
-import { UserPinsContext } from '@luna/contexts/displays/UserPinsContext';
-import { useAdminStatus } from '@luna/hooks/useAdminStatus';
-import { useLiveUser } from '@luna/hooks/useLiveUser';
-import { useCallback, useContext } from 'react';
+import { DisplayActionsMenu } from '@luna/components/DisplayActionsMenu';
 
 export interface DisplayContextMenuProps {
   username: string;
 }
 
 export function DisplayContextMenu({ username }: DisplayContextMenuProps) {
-  const { pinnedUsernames, setPinnedUsernames } = useContext(UserPinsContext);
-  const { isAdmin } = useAdminStatus();
-  const { setLiveUsername } = useLiveUser();
-
-  const isPinned = pinnedUsernames.contains(username);
-  const togglePinned = useCallback(() => {
-    setPinnedUsernames(
-      isPinned
-        ? pinnedUsernames.remove(username)
-        : pinnedUsernames.add(username)
-    );
-  }, [isPinned, pinnedUsernames, setPinnedUsernames, username]);
-
-  const goLive = useCallback(() => {
-    setLiveUsername(username);
-  }, [setLiveUsername, username]);
-
   return (
-    <DropdownMenu>
-      <DropdownItem key="pin" onPress={togglePinned}>
-        {isPinned ? 'Unpin' : 'Pin'} {username}
-      </DropdownItem>
-      {isAdmin ? (
-        <DropdownItem
-          key="live"
-          onPress={goLive}
-          className="text-danger"
-          color="danger"
-        >
-          Set {username} to Live
-        </DropdownItem>
-      ) : null}
-    </DropdownMenu>
+    <DisplayActionsMenu username={username}>
+      {({ items }) => (
+        <DropdownMenu>
+          {items.map(item => (
+            <DropdownItem
+              key={item.key}
+              onPress={item.onPress}
+              className={item.danger ? 'text-danger' : ''}
+              color={item.danger ? 'danger' : undefined}
+            >
+              {item.label}
+            </DropdownItem>
+          ))}
+        </DropdownMenu>
+      )}
+    </DisplayActionsMenu>
   );
 }

--- a/src/screens/home/displays/DisplayInspector.tsx
+++ b/src/screens/home/displays/DisplayInspector.tsx
@@ -1,4 +1,5 @@
 import { AuthContext } from '@luna/contexts/api/auth/AuthContext';
+import { useAdminStatus } from '@luna/hooks/useAdminStatus';
 import { DisplayInspectorActionsCard } from '@luna/screens/home/displays/DisplayInspectorActionsCard';
 import { DisplayInspectorApiTokenCard } from '@luna/screens/home/displays/DisplayInspectorApiTokenCard';
 import { DisplayInspectorInputCard } from '@luna/screens/home/displays/DisplayInspectorInputCard';
@@ -21,9 +22,8 @@ export function DisplayInspector({
   setInputConfig,
 }: DisplayInspectorProps) {
   const { user: me } = useContext(AuthContext);
-  const isMeOrAdmin =
-    username === me?.username ||
-    me?.roles.find(role => role.name === 'admin') !== undefined;
+  const { isAdmin } = useAdminStatus();
+  const isMeOrAdmin = username === me?.username || isAdmin;
 
   return (
     <div className="flex flex-col space-y-3">

--- a/src/screens/home/displays/DisplayInspector.tsx
+++ b/src/screens/home/displays/DisplayInspector.tsx
@@ -27,7 +27,7 @@ export function DisplayInspector({
 
   return (
     <div className="flex flex-col space-y-3">
-      <DisplayInspectorActionsCard />
+      <DisplayInspectorActionsCard username={username} />
       {/* <DisplayInspectorOptionsCard isEditable={isMeOrAdmin} /> */}
       {isMeOrAdmin ? (
         <>

--- a/src/screens/home/displays/DisplayInspector.tsx
+++ b/src/screens/home/displays/DisplayInspector.tsx
@@ -27,10 +27,10 @@ export function DisplayInspector({
 
   return (
     <div className="flex flex-col space-y-3">
+      <DisplayInspectorActionsCard />
       {/* <DisplayInspectorOptionsCard isEditable={isMeOrAdmin} /> */}
       {isMeOrAdmin ? (
         <>
-          <DisplayInspectorActionsCard />
           <DisplayInspectorApiTokenCard />
           <DisplayInspectorInputCard
             username={username}

--- a/src/screens/home/displays/DisplayInspector.tsx
+++ b/src/screens/home/displays/DisplayInspector.tsx
@@ -1,4 +1,5 @@
 import { AuthContext } from '@luna/contexts/api/auth/AuthContext';
+import { DisplayInspectorActionsCard } from '@luna/screens/home/displays/DisplayInspectorActionsCard';
 import { DisplayInspectorApiTokenCard } from '@luna/screens/home/displays/DisplayInspectorApiTokenCard';
 import { DisplayInspectorInputCard } from '@luna/screens/home/displays/DisplayInspectorInputCard';
 import { InputConfig } from '@luna/screens/home/displays/helpers/InputConfig';
@@ -29,6 +30,7 @@ export function DisplayInspector({
       {/* <DisplayInspectorOptionsCard isEditable={isMeOrAdmin} /> */}
       {isMeOrAdmin ? (
         <>
+          <DisplayInspectorActionsCard />
           <DisplayInspectorApiTokenCard />
           <DisplayInspectorInputCard
             username={username}

--- a/src/screens/home/displays/DisplayInspectorActionsCard.tsx
+++ b/src/screens/home/displays/DisplayInspectorActionsCard.tsx
@@ -1,0 +1,12 @@
+import { TitledCard } from '@luna/components/TitledCard';
+import { IconTarget } from '@tabler/icons-react';
+
+export interface DisplayInspectorActionsCardProps {}
+
+export function DisplayInspectorActionsCard({}: DisplayInspectorActionsCardProps) {
+  return (
+    <TitledCard icon={<IconTarget />} title="Actions">
+      TODO
+    </TitledCard>
+  );
+}

--- a/src/screens/home/displays/DisplayInspectorActionsCard.tsx
+++ b/src/screens/home/displays/DisplayInspectorActionsCard.tsx
@@ -1,12 +1,34 @@
+import { Button } from '@heroui/react';
+import { DisplayActionsMenu } from '@luna/components/DisplayActionsMenu';
 import { TitledCard } from '@luna/components/TitledCard';
 import { IconTarget } from '@tabler/icons-react';
 
-export interface DisplayInspectorActionsCardProps {}
+export interface DisplayInspectorActionsCardProps {
+  username: string;
+}
 
-export function DisplayInspectorActionsCard({}: DisplayInspectorActionsCardProps) {
+export function DisplayInspectorActionsCard({
+  username,
+}: DisplayInspectorActionsCardProps) {
   return (
     <TitledCard icon={<IconTarget />} title="Actions">
-      TODO
+      <DisplayActionsMenu username={username}>
+        {({ items }) => (
+          <div className="flex flex-col gap-1.5">
+            {items.map(item => (
+              <Button
+                key={item.key}
+                onPress={item.onPress}
+                variant="ghost"
+                size="sm"
+                color={item.danger ? 'danger' : undefined}
+              >
+                {item.label}
+              </Button>
+            ))}
+          </div>
+        )}
+      </DisplayActionsMenu>
     </TitledCard>
   );
 }

--- a/src/screens/home/displays/DisplayInspectorApiTokenCard.tsx
+++ b/src/screens/home/displays/DisplayInspectorApiTokenCard.tsx
@@ -17,19 +17,17 @@ export function DisplayInspectorApiTokenCard() {
 
   return (
     <TitledCard icon={<IconKey />} title="API Token">
-      <div className="flex flex-row items-center space-x-1">
-        <Tooltip content="Show the token">
-          <Button size="md" onPress={onOpen}>
-            Reveal
-          </Button>
-        </Tooltip>
+      <div className="flex flex-row justify-center items-center space-x-1">
+        <Button className="grow" size="sm" onPress={onOpen}>
+          Reveal Token
+        </Button>
         <ApiTokenModal
           token={token}
           isOpen={isOpen}
           onOpenChange={onOpenChange}
         />
         <Tooltip content="Copy the token">
-          <Button isIconOnly size="md" onPress={copyToClipboard}>
+          <Button isIconOnly size="sm" onPress={copyToClipboard}>
             <IconClipboard />
           </Button>
         </Tooltip>


### PR DESCRIPTION
### Fixes #110 

This exposes the display's actions as a card in the display inspector:

![Screenshot 2025-03-20 at 04 57 21](https://github.com/user-attachments/assets/07b9ffc1-1205-4d89-86b9-27f952a58ca7)

The underlying representation is shared with the context menu and has been factored out into a generic `<DisplayActionsMenu>` component.