### PR TITLE
Show viewed display's API token rather than the own token

### DIFF
--- a/src/contexts/api/model/ModelContext.tsx
+++ b/src/contexts/api/model/ModelContext.tsx
@@ -122,6 +122,16 @@ function messageToResult<T>(message: ServerMessage<T> | undefined): Result<T> {
   }
 }
 
+async function catchToResult<T>(
+  action: () => Promise<ServerMessage<T>> | undefined
+): Promise<Result<T>> {
+  try {
+    return messageToResult(await action());
+  } catch (error) {
+    return errorResult(error);
+  }
+}
+
 export function ModelContextProvider({ children }: ModelContextProviderProps) {
   const auth = useContext(AuthContext);
 
@@ -187,10 +197,10 @@ export function ModelContextProvider({ children }: ModelContextProviderProps) {
   const api: ModelAPI = useMemo(
     () => ({
       async list(path) {
-        return messageToResult(await client?.list(path));
+        return catchToResult(() => client?.list(path));
       },
       async get(path) {
-        return messageToResult(await client?.get(path));
+        return catchToResult(() => client?.get(path));
       },
       async *stream(path) {
         if (client) {
@@ -216,22 +226,22 @@ export function ModelContextProvider({ children }: ModelContextProviderProps) {
         }
       },
       async delete(path) {
-        return messageToResult(await client?.delete(path));
+        return catchToResult(() => client?.delete(path));
       },
       async put(path, payload) {
-        return messageToResult(await client?.put(path, payload));
+        return catchToResult(() => client?.put(path, payload));
       },
       async putLegacyInput(user, payload) {
-        return messageToResult(await client?.putModel(payload, user));
+        return catchToResult(() => client?.putModel(payload, user));
       },
       async putInput(user, payload) {
-        return messageToResult(await client?.putInput(payload, user));
+        return catchToResult(() => client?.putInput(payload, user));
       },
       async create(path) {
-        return messageToResult(await client?.create(path));
+        return catchToResult(() => client?.create(path));
       },
       async mkdir(path) {
-        return messageToResult(await client?.mkdir(path));
+        return catchToResult(() => client?.mkdir(path));
       },
       async isDirectory(path) {
         try {

--- a/src/modals/ApiTokenModal.tsx
+++ b/src/modals/ApiTokenModal.tsx
@@ -11,6 +11,7 @@ import {
 import { IconRefresh } from '@tabler/icons-react';
 
 export interface ApiTokenModalProps {
+  username?: string;
   token: Token | null;
   cycleToken: () => void;
   isOpen: boolean;
@@ -18,6 +19,7 @@ export interface ApiTokenModalProps {
 }
 
 export function ApiTokenModal({
+  username,
   token,
   cycleToken,
   isOpen,
@@ -28,13 +30,15 @@ export function ApiTokenModal({
       <ModalContent>
         {onClose => (
           <>
-            <ModalHeader>API Token</ModalHeader>
+            <ModalHeader>
+              {username ? `API Token for ${username}` : 'Your API Token'}
+            </ModalHeader>
             <ModalBody className="p-4">
               {token ? (
                 <>
                   {token.expiresAt ? (
                     <p>
-                      {`Your token is valid through ${token.expiresAt.toLocaleString()}.`}
+                      {`The token is valid through ${token.expiresAt.toLocaleString()}.`}
                     </p>
                   ) : null}
                   <Snippet symbol="">{token.value}</Snippet>

--- a/src/modals/ApiTokenModal.tsx
+++ b/src/modals/ApiTokenModal.tsx
@@ -12,7 +12,7 @@ import { IconRefresh } from '@tabler/icons-react';
 
 export interface ApiTokenModalProps {
   username?: string;
-  token: Token | null;
+  token: Token | null | undefined;
   cycleToken: () => void;
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
@@ -34,14 +34,16 @@ export function ApiTokenModal({
               {username ? `API Token for ${username}` : 'Your API Token'}
             </ModalHeader>
             <ModalBody className="p-4">
-              {token ? (
+              {token !== undefined ? (
                 <>
-                  {token.expiresAt ? (
+                  {token?.expiresAt ? (
                     <p>
                       {`The token is valid through ${token.expiresAt.toLocaleString()}.`}
                     </p>
                   ) : null}
-                  <Snippet symbol="">{token.value}</Snippet>
+                  <Snippet symbol="" disableCopy={token === null}>
+                    {token?.value ?? 'No token available'}
+                  </Snippet>
                   <Button onPress={cycleToken} variant="bordered">
                     <IconRefresh />
                     Generate New Token

--- a/src/screens/home/displays/DisplayInspector.tsx
+++ b/src/screens/home/displays/DisplayInspector.tsx
@@ -31,7 +31,7 @@ export function DisplayInspector({
       {/* <DisplayInspectorOptionsCard isEditable={isMeOrAdmin} /> */}
       {isMeOrAdmin ? (
         <>
-          <DisplayInspectorApiTokenCard />
+          <DisplayInspectorApiTokenCard username={username} />
           <DisplayInspectorInputCard
             username={username}
             inputState={inputState}

--- a/src/screens/home/displays/DisplayInspectorApiTokenCard.tsx
+++ b/src/screens/home/displays/DisplayInspectorApiTokenCard.tsx
@@ -17,7 +17,7 @@ export function DisplayInspectorApiTokenCard({
   const auth = useContext(AuthContext);
   const { users } = useContext(ModelContext);
   const { isOpen, onOpen, onOpenChange } = useDisclosure();
-  const [token, setToken] = useState<Token | null>(null);
+  const [token, setToken] = useState<Token | null>(); // undefined means loading, null means unavailable
 
   const userId = users.all.get(username)?.id;
 

--- a/src/screens/home/displays/DisplayInspectorApiTokenCard.tsx
+++ b/src/screens/home/displays/DisplayInspectorApiTokenCard.tsx
@@ -60,7 +60,12 @@ export function DisplayInspectorApiTokenCard({
           onOpenChange={onOpenChange}
         />
         <Tooltip content="Copy the token">
-          <Button isIconOnly size="sm" onPress={copyToClipboard}>
+          <Button
+            isIconOnly
+            size="sm"
+            onPress={copyToClipboard}
+            isDisabled={!token}
+          >
             <IconClipboard />
           </Button>
         </Tooltip>

--- a/src/screens/home/displays/DisplayInspectorApiTokenCard.tsx
+++ b/src/screens/home/displays/DisplayInspectorApiTokenCard.tsx
@@ -33,15 +33,16 @@ export function DisplayInspectorApiTokenCard({
 
   useEffect(() => {
     (async () => {
-      if (!userId) {
-        return;
+      if (userId) {
+        const result = await auth.getToken(userId);
+        if (result.ok) {
+          setToken(result.value);
+          return;
+        } else {
+          console.warn(`Could not fetch token: ${result.error}`);
+        }
       }
-      const result = await auth.getToken(userId);
-      if (!result.ok) {
-        console.warn(`Could not fetch token: ${result.error}`);
-        return;
-      }
-      setToken(result.value);
+      setToken(null);
     })();
   }, [auth, userId]);
 
@@ -52,6 +53,7 @@ export function DisplayInspectorApiTokenCard({
           Reveal Token
         </Button>
         <ApiTokenModal
+          username={username}
           token={token}
           cycleToken={cycleToken}
           isOpen={isOpen}


### PR DESCRIPTION
This lets admins view and regenerate other users' tokens too