### PR TITLE
Fix token cycling bug

### DIFF
--- a/src/screens/home/sidebar/Sidebar.tsx
+++ b/src/screens/home/sidebar/Sidebar.tsx
@@ -50,6 +50,8 @@ export function Sidebar({ isCompact }: SidebarProps) {
     }
   }, [isCompact, query]);
 
+  const cycleToken = useCallback(async () => await auth.cycleToken(), [auth]);
+
   return (
     <div className="flex flex-col space-y-2 h-full">
       <SearchBar
@@ -78,7 +80,7 @@ export function Sidebar({ isCompact }: SidebarProps) {
         <UserSnippet
           user={auth.user}
           token={auth.token}
-          cycleToken={auth.cycleToken}
+          cycleToken={cycleToken}
         />
       ) : null}
       <div className="flex flex-row justify-between items-center">


### PR DESCRIPTION
Passing this method directly resulted in a strange bug, not caught by TypeScript's type system:

- `auth.cycleToken` has type `(id?: number) => void`
- `UserSnippet` takes `() => void`
- The actual downstream component takes `(e: SomeEvent) => void`

For some reason TypeScript considered these conversions to be safe, even though the event object ended up being passed as a number parameter, which definitely isn't safe. Hence why we wrap it in a callback here.