### PR TITLE
Merge values in `useLocalStorage`

### DIFF
--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -7,7 +7,26 @@ export function useLocalStorage<T>(
 ) {
   const [value, setValue] = useState<T>(() => {
     const raw = localStorage.getItem(key);
-    return raw ? JSON.parse(raw) : defaultValue();
+    let value = defaultValue();
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (typeof value === typeof parsed) {
+        if (typeof value === 'object') {
+          // Merge objects by only considering known keys
+          for (const key in value) {
+            if (key in parsed) {
+              value[key] = parsed[key];
+            }
+          }
+        } else {
+          value = parsed;
+        }
+      } else {
+        // We stored something else and will just keep the default
+        // This might happen if the frontend updated this to a different type
+      }
+    }
+    return value;
   });
 
   const json = useMemo(() => JSON.stringify(value), [value]);

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,6 +1,26 @@
 import { LocalStorageKey } from '@luna/constants/LocalStorageKey';
 import { useEffect, useMemo, useState } from 'react';
 
+/** Recursively merges two values, discarding anything not matching `base`'s schema. */
+function merge(base: any, delta: any): any {
+  if (typeof base === typeof delta) {
+    // TODO: This doesn't deal with schema changes in arrays, where stale values
+    // from the delta may still be kept. Is this a case we need to consider?
+    if (typeof base === 'object' && !Array.isArray(base)) {
+      const merged = { ...base };
+      for (const key in base) {
+        if (key in delta) {
+          merged[key] = merge(base[key], delta[key]);
+        }
+      }
+      return merged;
+    } else {
+      return delta;
+    }
+  }
+  return base;
+}
+
 export function useLocalStorage<T>(
   key: LocalStorageKey,
   defaultValue: () => T
@@ -10,21 +30,7 @@ export function useLocalStorage<T>(
     let value = defaultValue();
     if (raw) {
       const parsed = JSON.parse(raw);
-      if (typeof value === typeof parsed) {
-        if (typeof value === 'object') {
-          // Merge objects by only considering known keys
-          for (const key in value) {
-            if (key in parsed) {
-              value[key] = parsed[key];
-            }
-          }
-        } else {
-          value = parsed;
-        }
-      } else {
-        // We stored something else and will just keep the default
-        // This might happen if the frontend updated this to a different type
-      }
+      value = merge(value, parsed);
     }
     return value;
   });


### PR DESCRIPTION
This effectively 'repairs' data in users' local storage, by only keeping data under known keys, making it more robust against schema changes. The known keys are determined by the default value, which is used whenever there's a mismatch.