### PR TITLE
Throttle motion and orientation events

### DIFF
--- a/src/screens/home/displays/DisplayView.tsx
+++ b/src/screens/home/displays/DisplayView.tsx
@@ -374,10 +374,9 @@ export function DisplayView() {
           type: 'orientation',
           source: clientId,
           absolute: e.absolute,
-          // TODO: Fix this
-          alpha: e.alpha ?? 0,
-          beta: e.beta ?? 0,
-          gamma: e.gamma ?? 0,
+          alpha: e.alpha,
+          beta: e.beta,
+          gamma: e.gamma,
         };
 
         const event = addAny<OrientationEvent | null>(lastEvent, delta);

--- a/src/screens/home/displays/helpers/InputConfig.ts
+++ b/src/screens/home/displays/helpers/InputConfig.ts
@@ -6,5 +6,7 @@ export interface InputConfig {
   gamepadEnabled: boolean;
   midiEnabled: boolean;
   orientationEnabled: boolean;
+  orientationIntervalMs: number;
   motionEnabled: boolean;
+  motionIntervalMs: number;
 }

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,0 +1,14 @@
+export function addAny<T>(lhs: T, rhs: T): T {
+  if (lhs !== null && rhs !== null) {
+    if (typeof lhs === 'object' && typeof rhs === 'object') {
+      const sum = { ...lhs };
+      for (const key in lhs) {
+        sum[key] = addAny(lhs[key] as any, rhs[key] as any);
+      }
+      return sum;
+    } else if (typeof lhs === 'number' && typeof rhs === 'number') {
+      return (lhs + rhs) as T;
+    }
+  }
+  return rhs;
+}


### PR DESCRIPTION
These events currently fire very quickly and may cause troubling loads on the server. For this reason, we limit the motion/orientation event rate to 50ms for now.