### PR TITLE
Use regular deviceorientation event key again

### DIFF
--- a/src/screens/home/displays/DisplayView.tsx
+++ b/src/screens/home/displays/DisplayView.tsx
@@ -386,11 +386,9 @@ export function DisplayView() {
         }
       };
 
-      // @ts-ignore
-      window.addEventListener('deviceorientationabsolute', listener);
+      window.addEventListener('deviceorientation', listener);
       return () => {
-        // @ts-ignore
-        window.removeEventListener('deviceorientationabsolute', listener);
+        window.removeEventListener('deviceorientation', listener);
       };
     })();
   }, [


### PR DESCRIPTION
iOS Safari seems to yield absolute events here anyway and doesn't understand `deviceorientationabsolute`.