### PR TITLE
Improve full screen layout for home content

### DIFF
--- a/src/components/ObjectInspectorTable.tsx
+++ b/src/components/ObjectInspectorTable.tsx
@@ -67,6 +67,7 @@ export function ObjectInspectorTable<T extends object>({
       hideHeader
       layout="fixed"
       classNames={{
+        base: 'overflow-y-visible',
         table: 'bg-red',
       }}
       removeWrapper

--- a/src/components/TimeInterval.tsx
+++ b/src/components/TimeInterval.tsx
@@ -8,16 +8,16 @@ export function TimeInterval({
   layout = 'horizontal',
 }: TimeIntervalProps) {
   const seconds = Math.floor(rawSeconds);
-  const components: string[] = [`${seconds % 60} s`];
+  const components: string[] = [`${seconds % 60}s`];
   if (seconds > 60) {
     const minutes = Math.floor(seconds / 60);
-    components.push(`${minutes % 60} m`);
+    components.push(`${minutes % 60}m`);
     if (minutes > 60) {
       const hours = Math.floor(minutes / 60);
-      components.push(`${hours % 24} h`);
+      components.push(`${hours % 24}h`);
       if (hours > 24) {
         const days = Math.floor(hours / 24);
-        components.push(`${days} d`);
+        components.push(`${days}d`);
       }
     }
   }

--- a/src/screens/home/HomeContent.tsx
+++ b/src/screens/home/HomeContent.tsx
@@ -1,9 +1,14 @@
+import {
+  defaultHomeContentLayout,
+  HomeContentLayout,
+} from '@luna/screens/home/helpers/HomeContentLayout';
 import { ReactNode, useEffect } from 'react';
 import { useOutletContext } from 'react-router-dom';
 
 export interface HomeContentProps {
   title: string;
   toolbar?: ReactNode;
+  layout?: HomeContentLayout;
   children: ReactNode;
 }
 
@@ -11,15 +16,29 @@ export interface HomeContentContext {
   setTitle(title: string): void;
 
   setToolbar(toolbar: ReactNode): void;
+
+  setLayout(layout: HomeContentLayout): void;
 }
 
-export function HomeContent({ title, toolbar, children }: HomeContentProps) {
+export function HomeContent({
+  title,
+  toolbar,
+  children,
+  layout = defaultHomeContentLayout,
+}: HomeContentProps) {
   const context = useOutletContext<HomeContentContext>();
 
   useEffect(() => {
     context.setTitle(title);
+  }, [context, title]);
+
+  useEffect(() => {
     context.setToolbar(toolbar);
-  }, [title, toolbar, context]);
+  }, [toolbar, context]);
+
+  useEffect(() => {
+    context.setLayout(layout);
+  }, [context, layout]);
 
   return <>{children}</>;
 }

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -12,6 +12,10 @@ import React, {
 } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { QuickSwitcherModal } from '@luna/modals/QuickSwitcherModal';
+import {
+  defaultHomeContentLayout,
+  HomeContentLayout,
+} from '@luna/screens/home/helpers/HomeContentLayout';
 
 export function HomeScreen() {
   const location = useLocation();
@@ -24,8 +28,11 @@ export function HomeScreen() {
 
   const [title, setTitle] = useState('');
   const [toolbar, setToolbar] = useState<ReactNode>();
+  const [layout, setLayout] = useState<HomeContentLayout>(
+    defaultHomeContentLayout
+  );
 
-  const outletContext: HomeContentContext = { setTitle, setToolbar };
+  const outletContext: HomeContentContext = { setTitle, setToolbar, setLayout };
 
   useLayoutEffect(() => {
     setExpanded(false);
@@ -54,7 +61,9 @@ export function HomeScreen() {
   }, [isCompact, isExpanded]);
 
   return (
-    <div className={`flex ${isCompact ? 'flex-col h-full' : 'flex-row'}`}>
+    <div
+      className={`flex ${isCompact ? 'flex-col' : 'flex-row'} ${isCompact || layout === 'fullScreen' ? 'h-full' : ''}`}
+    >
       {!isCompact ? (
         <div className="grow-0 shrink-0 basis-64 sticky top-0 h-screen p-5">
           <Sidebar isCompact={isCompact} />
@@ -77,7 +86,7 @@ export function HomeScreen() {
             <Sidebar isCompact={isCompact} />
           </div>
         ) : null}
-        <div className="grow p-5">
+        <div className={`grow p-5 ${layout === 'fullScreen' ? 'h-full' : ''}`}>
           <Outlet context={outletContext} />
         </div>
       </div>

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -70,7 +70,7 @@ export function HomeScreen() {
         </div>
       ) : null}
       <div className="flex flex-col grow">
-        <div className="flex flex-row items-center space-x-4 sticky top-0 z-50 p-5 bg-white/70 dark:bg-black/30 backdrop-blur-2xl">
+        <div className="flex flex-row space-x-4 sticky top-0 z-50 h-[75px] p-5 bg-white/70 dark:bg-black/30 backdrop-blur-2xl">
           {isCompact ? (
             <Button isIconOnly onPress={toggleExpanded}>
               <IconMenu2 />
@@ -78,7 +78,7 @@ export function HomeScreen() {
           ) : null}
           <div className="grow flex flex-row justify-between">
             <h2 className="text-3xl">{title}</h2>
-            {toolbar}
+            <div className="flex flex-row items-center">{toolbar}</div>
           </div>
         </div>
         {isCompact && isExpanded ? (
@@ -86,7 +86,9 @@ export function HomeScreen() {
             <Sidebar isCompact={isCompact} />
           </div>
         ) : null}
-        <div className={`grow p-5 ${layout === 'fullScreen' ? 'h-full' : ''}`}>
+        <div
+          className={`grow p-5 ${layout === 'fullScreen' ? 'h-[calc(100%-75px)]' : ''}`}
+        >
           <Outlet context={outletContext} />
         </div>
       </div>

--- a/src/screens/home/admin/MonitorInspectorLampsCard.tsx
+++ b/src/screens/home/admin/MonitorInspectorLampsCard.tsx
@@ -37,20 +37,22 @@ export function MonitorInspectorLampsCard({
     paddedMetrics.push(null);
   }
   return (
-    <TitledCard icon={<IconLamp />} title="Lamps">
+    <TitledCard icon={<IconLamp />} title="Lamps" isCollapsible>
       {metrics.length > 0 ? (
-        <ObjectInspectorTable
-          objects={paddedMetrics}
-          names={names}
-          labelWidth={150}
-          selection={criterion?.key}
-          onSelect={key =>
-            setCriterion(key ? { type: 'lamp', key } : undefined)
-          }
-          render={(value, prop) => (
-            <MonitorInspectorLampValue value={value} prop={prop} />
-          )}
-        />
+        <div>
+          <ObjectInspectorTable
+            objects={paddedMetrics}
+            names={names}
+            labelWidth={150}
+            selection={criterion?.key}
+            onSelect={key =>
+              setCriterion(key ? { type: 'lamp', key } : undefined)
+            }
+            render={(value, prop) => (
+              <MonitorInspectorLampValue value={value} prop={prop} />
+            )}
+          />
+        </div>
       ) : (
         <div className="opacity-50">No lamps selected</div>
       )}

--- a/src/screens/home/admin/MonitorInspectorRoomCard.tsx
+++ b/src/screens/home/admin/MonitorInspectorRoomCard.tsx
@@ -56,7 +56,11 @@ export function MonitorInspectorRoomCard({
   );
 
   return (
-    <TitledCard icon={<IconDoor />} title={`Room ${metrics?.room ?? ''}`}>
+    <TitledCard
+      icon={<IconDoor />}
+      title={`Room ${metrics?.room ?? ''}`}
+      isCollapsible
+    >
       {metrics ? (
         <ObjectInspectorTable
           objects={renderedMetrics}

--- a/src/screens/home/admin/MonitorView.tsx
+++ b/src/screens/home/admin/MonitorView.tsx
@@ -228,7 +228,10 @@ export function MonitorView() {
   const isColumnLayout = breakpoint < Breakpoint.Xl;
 
   return (
-    <HomeContent title="Monitoring" layout="fullScreen">
+    <HomeContent
+      title="Monitoring"
+      layout={isColumnLayout ? 'scrollable' : 'fullScreen'}
+    >
       <div className="flex flex-col gap-4 xl:flex-row h-full">
         <div
           ref={wrapperRef}

--- a/src/screens/home/admin/MonitorView.tsx
+++ b/src/screens/home/admin/MonitorView.tsx
@@ -251,7 +251,9 @@ export function MonitorView() {
             isColumnLayout ? '' : 'flex flex-row justify-end grow-0 xl:w-[45%]'
           }
         >
-          <div className={isColumnLayout ? '' : 'overflow-y-scroll'}>
+          <div
+            className={`${isColumnLayout ? '' : 'overflow-y-scroll'} w-full`}
+          >
             <MonitorInspector
               criterion={criterion}
               setCriterion={setCriterion}

--- a/src/screens/home/admin/MonitorView.tsx
+++ b/src/screens/home/admin/MonitorView.tsx
@@ -228,8 +228,8 @@ export function MonitorView() {
   const isColumnLayout = breakpoint < Breakpoint.Xl;
 
   return (
-    <HomeContent title="Monitoring">
-      <div className="flex flex-col space-y-4 xl:flex-row h-full">
+    <HomeContent title="Monitoring" layout="fullScreen">
+      <div className="flex flex-col gap-4 xl:flex-row h-full">
         <div
           ref={wrapperRef}
           className="grow flex flex-row justify-center h-full"
@@ -251,13 +251,15 @@ export function MonitorView() {
             isColumnLayout ? '' : 'flex flex-row justify-end grow-0 xl:w-[45%]'
           }
         >
-          <MonitorInspector
-            criterion={criterion}
-            setCriterion={setCriterion}
-            flatRoomMetrics={focusedFlatRoomMetrics}
-            lampMetrics={focusedLampMetrics}
-            padLampCount={isColumnLayout ? 0 : 6}
-          />
+          <div className={isColumnLayout ? '' : 'overflow-y-scroll'}>
+            <MonitorInspector
+              criterion={criterion}
+              setCriterion={setCriterion}
+              flatRoomMetrics={focusedFlatRoomMetrics}
+              lampMetrics={focusedLampMetrics}
+              padLampCount={isColumnLayout ? 0 : 6}
+            />
+          </div>
         </div>
       </div>
     </HomeContent>

--- a/src/screens/home/displays/DisplayView.tsx
+++ b/src/screens/home/displays/DisplayView.tsx
@@ -524,7 +524,7 @@ export function DisplayView() {
       : maxSize.height * DISPLAY_ASPECT_RATIO;
 
   return (
-    <HomeContent title={`${username}'s Display`}>
+    <HomeContent title={`${username}'s Display`} layout="fullScreen">
       <div className="flex flex-col space-y-4 md:flex-row h-full">
         <div
           ref={wrapperRef}
@@ -549,13 +549,15 @@ export function DisplayView() {
             />
           </motion.div>
         </div>
-        <DisplayInspector
-          username={username}
-          inputState={inputState}
-          inputConfig={inputConfig}
-          setInputConfig={setInputConfig}
-          inputCapabilities={inputCapabilities}
-        />
+        <div className="md:overflow-y-scroll">
+          <DisplayInspector
+            username={username}
+            inputState={inputState}
+            inputConfig={inputConfig}
+            setInputConfig={setInputConfig}
+            inputCapabilities={inputCapabilities}
+          />
+        </div>
       </div>
     </HomeContent>
   );

--- a/src/screens/home/helpers/HomeContentLayout.ts
+++ b/src/screens/home/helpers/HomeContentLayout.ts
@@ -1,0 +1,3 @@
+export type HomeContentLayout = 'fullScreen' | 'scrollable';
+
+export const defaultHomeContentLayout: HomeContentLayout = 'scrollable';


### PR DESCRIPTION
This adds a new customizable layout property to `HomeContent` for content that chooses to span the entire screen, which constrains the content to the browser height. This makes it possible to e.g. nest scroll containers which otherwise would have grown beyond the viewport.