### PR TITLE
Only include the username in the display title in compact layout

### DIFF
--- a/src/screens/home/displays/DisplayView.tsx
+++ b/src/screens/home/displays/DisplayView.tsx
@@ -532,7 +532,7 @@ export function DisplayView() {
 
   return (
     <HomeContent
-      title={`${username}'s Display`}
+      title={isCompact ? username : `${username}'s Display`}
       toolbar={<DisplayToolbar tab={inspectorTab} setTab={setInspectorTab} />}
       layout="fullScreen"
     >


### PR DESCRIPTION
The long title doesn't fit on small phone screens.