### PR TITLE
Always show the current display in the visible routes

### DIFF
--- a/src/screens/home/sidebar/SidebarRoutes.tsx
+++ b/src/screens/home/sidebar/SidebarRoutes.tsx
@@ -9,6 +9,7 @@ import {
 import { truncate } from '@luna/utils/string';
 import { useContext, useMemo } from 'react';
 import { InView } from 'react-intersection-observer';
+import { useLocation } from 'react-router-dom';
 
 export interface SidebarRoutesProps {
   isCompact: boolean;
@@ -41,9 +42,11 @@ function filterRoutes(
 
 export function SidebarRoutes({ isCompact, searchQuery }: SidebarRoutesProps) {
   const { query: displaySearchQuery } = useContext(DisplaySearchContext);
+  const location = useLocation();
 
   const visibleRouteItems = useVisibleRoutes({
     showUserDisplays: !isCompact || searchQuery.length > 0,
+    activePath: location.pathname,
     displaySearchQuery,
   });
 


### PR DESCRIPTION
In compact mode, the current display may be hidden in the menu, which can be confusing UX-wise. This patch therefore makes sure that the current display is always shown.