### PR TITLE
Add button for clearing display search query to visible routes/sidebar

### DIFF
--- a/src/hooks/useVisibleRoutes.tsx
+++ b/src/hooks/useVisibleRoutes.tsx
@@ -34,7 +34,13 @@ export interface VisibleRoute extends BaseVisibleItem<'route'> {
 
 export interface VisibleDivider extends BaseVisibleItem<'divider'> {}
 
-export type VisibleRouteItem = VisibleRoute | VisibleDivider;
+export interface VisibleClearDisplaySearchButton
+  extends BaseVisibleItem<'clearDisplaySearch'> {}
+
+export type VisibleRouteItem =
+  | VisibleRoute
+  | VisibleDivider
+  | VisibleClearDisplaySearchButton;
 
 const displaysPath = '/displays';
 
@@ -152,6 +158,14 @@ export function useVisibleRoutes({
                   ...displayRoute(username),
                   isLazyLoaded: true,
                 })),
+                ...(displaySearchQuery
+                  ? [
+                      {
+                        type: 'clearDisplaySearch' as const,
+                        name: 'Clear Display Search',
+                      },
+                    ]
+                  : []),
               ]
             : activeDisplayName && !pinnedDisplays.has(activeDisplayName)
               ? [displayRoute(activeDisplayName)]

--- a/src/screens/home/displays/DisplaysToolbar.tsx
+++ b/src/screens/home/displays/DisplaysToolbar.tsx
@@ -44,7 +44,7 @@ export function DisplaysToolbar({
       ) : null}
       <SearchBar
         placeholder="Search displays..."
-        initialQuery={query}
+        query={query}
         setQuery={setQuery}
         className="max-w-48"
       />


### PR DESCRIPTION
This fixes a slightly confusing UX issue where not all displays would be displayed, because the user added a filter in the display grid.